### PR TITLE
fix(channel): bypass manifest cache on every install path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,15 @@ patch-level dev builds are too granular to list individually.
 
 ## [Unreleased]
 
-### Removed
-- The deprecated `update.manifestBase` config field is gone from `telad.yaml`, `telahubd.yaml`, and `~/.tela/credentials.yaml`, along with the in-process `MigrateManifestBase` migration helper that ported pre-0.12 configs to the `update.sources` map shape on first load. Operators upgrading directly from pre-0.12 to 0.13+ should run `tela channel sources set <channel> <url>` (or its `telad`/`telahubd` equivalents) before relying on the channel; an old config still parses (yaml.v3 silently drops unknown fields), but a custom channel previously pointed at by `manifestBase` will fail its next manifest fetch with an empty URL.
+### Fixed
+- `tela update`, `telad update`, `telahubd update`, the hub admin `POST /api/admin/update` endpoint, the agent `update` mgmt action, and TelaVisor's local-binary install paths now bypass the channel-manifest cache. Previously a 5-minute in-process cache could make an install path read a stale manifest and refuse a freshly-published tag (or, for TV-mediated agent updates, send the agent a version that did not match what the agent saw on its own fetch). Status displays still use the cached path; only the install side fetches fresh.
 
 ### Changed
 - The hub's "default update" message pushed to registering agents now carries an `update.sources` map instead of the legacy `manifestBase` scalar. Agents merge the map into their local sources, with local entries winning on conflict so a deliberately-set agent-side URL is never overwritten silently.
 - The legacy `manifestBase` field on `PATCH /api/admin/update` request bodies and on the agent `update-channel` mgmt action is now redirected into `sources[channel]` server-side. The `-manifest-base` CLI flag on `tela admin hub channel set` and `tela admin agent ... channel set` continues to work; the operator-facing API shape is unchanged.
 
-Closes #59.
+### Removed
+- The deprecated `update.manifestBase` config field is gone from `telad.yaml`, `telahubd.yaml`, and `~/.tela/credentials.yaml`, along with the in-process `MigrateManifestBase` migration helper that ported pre-0.12 configs to the `update.sources` map shape on first load. Operators upgrading directly from pre-0.12 to 0.13+ should run `tela channel sources set <channel> <url>` (or its `telad`/`telahubd` equivalents) before relying on the channel; an old config still parses (yaml.v3 silently drops unknown fields), but a custom channel previously pointed at by `manifestBase` will fail its next manifest fetch with an empty URL. Closes #59.
 
 ## [0.12.0] - 2026-04-20
 

--- a/cmd/telagui/app.go
+++ b/cmd/telagui/app.go
@@ -553,7 +553,8 @@ func (a *App) GetUpdateInfo() UpdateInfo {
 // Reads from the client's configured channel manifest end-to-end so
 // dev/beta/stable users get the right tag and SHA-256 verification.
 func (a *App) RestartToUpdate() error {
-	m, err := a.clientChannelManifest()
+	// Bypass the manifest cache: this is an install path.
+	m, err := a.clientChannelManifestFresh()
 	if err != nil {
 		return fmt.Errorf("fetch channel manifest: %w", err)
 	}
@@ -3294,8 +3295,12 @@ func (a *App) updateRunningServiceBinary(binaryName string) string {
 		}
 		// Pass TV's own channel manifest coordinates so the agent fetches
 		// from the same source TV is using (e.g. a self-hosted channel
-		// server), not from whatever its own YAML config says.
-		m, err := a.clientChannelManifest()
+		// server), not from whatever its own YAML config says. Bypass the
+		// manifest cache here because the agent's install path also
+		// bypasses; if either side reads a stale entry, the version TV
+		// sends and the version the agent sees on its own fetch can
+		// diverge and the install gets refused.
+		m, err := a.clientChannelManifestFresh()
 		if err != nil {
 			return fmt.Sprintf(`{"error":"fetch channel manifest: %s"}`, jsonEscape(err.Error()))
 		}
@@ -3369,7 +3374,8 @@ func (a *App) updateUnmanagedBinary(binaryName string) string {
 		exePath = filepath.Join(a.effectiveBinPath(), binaryName+ext)
 	}
 
-	m, err := a.clientChannelManifest()
+	// Bypass the manifest cache: this is an install path.
+	m, err := a.clientChannelManifestFresh()
 	if err != nil {
 		return fmt.Sprintf(`{"error":"fetch channel manifest: %s"}`, jsonEscape(err.Error()))
 	}
@@ -3952,7 +3958,8 @@ func (a *App) InstallBinary(name string) error {
 		return fmt.Errorf("create bin dir: %w", err)
 	}
 
-	m, err := a.clientChannelManifest()
+	// Bypass the manifest cache: this is an install path.
+	m, err := a.clientChannelManifestFresh()
 	if err != nil {
 		return fmt.Errorf("fetch channel manifest: %w", err)
 	}
@@ -4048,6 +4055,24 @@ func (a *App) clientChannelManifest() (*channelpkg.Manifest, error) {
 	return tvChannelFetcher.GetURL(channelpkg.ManifestURL(base, ch))
 }
 
+// clientChannelManifestFresh is the install-path companion to
+// clientChannelManifest: it bypasses the manifest cache so a freshly
+// published tag is never refused (or mis-installed) because a 5-minute
+// cached entry is still warm. Use this from any code that is about to
+// download a binary; status displays should keep using the cached form.
+func (a *App) clientChannelManifestFresh() (*channelpkg.Manifest, error) {
+	store, err := credstore.Load(credstore.UserPath())
+	var ch string
+	var sources map[string]string
+	if err == nil && store != nil {
+		ch = store.Update.Channel
+		sources = store.Update.Sources
+	}
+	ch = channelpkg.Normalize(ch)
+	base := channelpkg.ResolveBase(ch, sources)
+	return tvChannelFetcher.Fetch(channelpkg.ManifestURL(base, ch))
+}
+
 // latestRelease returns the current version on the client's configured
 // release channel. Replaces the old GitHub /releases/latest call so that
 // dev/beta/stable users see the right "available" target.
@@ -4066,8 +4091,9 @@ func (a *App) installTool(name, version string) (string, error) {
 	}
 
 	// version is a hint from the caller; the channel manifest is the
-	// authoritative source for both the URL and the SHA-256.
-	m, err := a.clientChannelManifest()
+	// authoritative source for both the URL and the SHA-256. Bypass the
+	// cache here so a just-published tag is honoured immediately.
+	m, err := a.clientChannelManifestFresh()
 	if err != nil {
 		return "", fmt.Errorf("fetch channel manifest: %w", err)
 	}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1002,7 +1002,11 @@ func downloadAndStageUpdate(lg *log.Logger, ver, chOverride, baseOverride string
 	if baseOverride != "" {
 		base = baseOverride
 	}
-	m, err := agentChannelFetcher.GetURL(channel.ManifestURL(base, ch))
+	// Install paths bypass the manifest cache: a stale manifest would
+	// make us refuse a freshly-published version or install the wrong
+	// bytes. Display paths (e.g. channel-status polling) continue to
+	// use GetURL with its 5-minute TTL.
+	m, err := agentChannelFetcher.Fetch(channel.ManifestURL(base, ch))
 	if err != nil {
 		return fmt.Errorf("fetch %s manifest: %w", ch, err)
 	}

--- a/internal/agent/update.go
+++ b/internal/agent/update.go
@@ -94,7 +94,9 @@ func cmdSelfUpdate(args []string) {
 		fmt.Fprintf(os.Stderr, "Error: channel %q has no source URL; run 'telad channel sources set %s <url>' or switch to a built-in channel.\n", ch, ch)
 		os.Exit(1)
 	}
-	m, err := agentChannelFetcher.GetURL(channel.ManifestURL(base, ch))
+	// Bypass the manifest cache on the install path so we never refuse a
+	// just-published tag because a stale entry is still warm.
+	m, err := agentChannelFetcher.Fetch(channel.ManifestURL(base, ch))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: fetch %s manifest: %v\n", ch, err)
 		os.Exit(1)

--- a/internal/hub/admin_api.go
+++ b/internal/hub/admin_api.go
@@ -1195,7 +1195,9 @@ func hubDownloadAndStage(ver string) error {
 	binaryName := fmt.Sprintf("telahubd-%s-%s%s", runtime.GOOS, runtime.GOARCH, ext)
 
 	ch, base := hubChannel()
-	m, err := hubChannelFetcher.GetURL(channel.ManifestURL(base, ch))
+	// Install paths bypass the manifest cache. See the agent-side note
+	// in downloadAndStageUpdate.
+	m, err := hubChannelFetcher.Fetch(channel.ManifestURL(base, ch))
 	if err != nil {
 		return fmt.Errorf("fetch %s manifest: %w", ch, err)
 	}

--- a/internal/hub/update.go
+++ b/internal/hub/update.go
@@ -97,7 +97,9 @@ func cmdSelfUpdate(args []string) {
 		fmt.Fprintf(os.Stderr, "Error: channel %q has no source URL; run 'telahubd channel sources set %s <url>' or switch to a built-in channel.\n", ch, ch)
 		os.Exit(1)
 	}
-	m, err := hubChannelFetcher.GetURL(channel.ManifestURL(base, ch))
+	// Bypass the manifest cache on the install path so we never refuse a
+	// just-published tag because a stale entry is still warm.
+	m, err := hubChannelFetcher.Fetch(channel.ManifestURL(base, ch))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: fetch %s manifest: %v\n", ch, err)
 		os.Exit(1)


### PR DESCRIPTION
## Summary

Fixes a class of install-path bugs caused by the channel manifest's 5-minute in-process cache. Status-display callers benefit from caching (TV polling agent status every few seconds shouldn't hammer the manifest URL), but install paths must always revalidate before extracting bytes on disk.

## Repro / Root cause

After publishing a new local-channel build to owlsnest, triggering a TV-mediated agent update on barn produced:

```
mgmt: update requested version="v0.13.0-local.55" channel="local" manifestBase="https://owlsnest.parkscomputing.com/channels/"
mgmt: update failed: requested version v0.13.0-local.55 is not the current local on channel local (which is v0.12.0-local.54); switch channel or wait for promotion
```

owlsnest's `local.json` was correctly serving `v0.13.0-local.55`. But:

- TV's `tvChannelFetcher` had a fresh manifest (TV process had just been restarted from a fresh build).
- barn's `agentChannelFetcher` had a 4-minute-old cached entry from a routine status check, still saying `v0.12.0-local.54`.

TV sent `version=v0.13.0-local.55` to barn. barn's install path called `GetURL` to verify, hit the cache, returned the stale manifest, and the version comparison rejected the update.

## Fix

Every install-path call site switches from `Fetcher.GetURL` (cached, 5-minute TTL, serves stale on failure) to `Fetcher.Fetch` (always hits the network, refreshes the cache on success).

Sites converted:

- `internal/agent/agent.go` `downloadAndStageUpdate` (mgmt-driven update)
- `internal/agent/update.go` `cmdSelfUpdate` (telad CLI)
- `internal/hub/admin_api.go` `hubDownloadAndStage` (admin-driven update)
- `internal/hub/update.go` `cmdSelfUpdate` (telahubd CLI)
- `cmd/telagui/app.go` `RestartToUpdate`, `UpdateLocalService`, `InstallBinary`, and the hub-mediated agent update path -- via a new `clientChannelManifestFresh` helper that mirrors the cached `clientChannelManifest` but uses `Fetch`.

Display callers (`GetToolVersions`, `checkForUpdates`, `GetHubChannelInfo`, `GetAgentChannelInfo`, channel-status mgmt actions, and the printable `channel show` commands) continue to use `GetURL` with its 5-minute TTL. The cache is updated by every `Fetch`, so display paths see post-install data without an extra round trip.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l .`, `go test ./...` clean
- [ ] Manual: publish a new local-channel build, immediately trigger TV update on a remote agent that polled status within the last 5 minutes. Should succeed instead of hitting the version-mismatch error.

## CHANGELOG

Entry added under `[Unreleased]` > Fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)