### PR TITLE
feat(docker): Docker-first telahubd distribution (#58)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,33 @@
+# Files excluded from the Docker build context for Dockerfile.telahubd.
+# Anything not needed by `go build ./cmd/telahubd` is excluded so the
+# context stays small and unrelated edits don't bust the build cache.
+
+# Local build output and binary debris.
+dist/
+*.exe
+*.exe.old
+*.exe~
+
+# Local VS Code workspace, scripts, and personal config.
+.vscode/
+scripts/
+
+# Documentation that is not consumed by the Go build.
+book/
+*.md
+
+# Other binary trees that don't ship in telahubd.
+cmd/telagui/
+cmd/telaportal/
+cmd/tela/
+cmd/telad/
+
+# Local service configs that may contain secrets.
+*-telahubd.yaml
+*-telad.yaml
+
+# Git metadata.
+.git/
+.github/
+.gitignore
+.gitattributes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,7 @@ on:
 
 permissions:
   contents: write  # needed to create releases and upload assets
+  packages: write  # needed to push telahubd images to ghcr.io
 
 env:
   GO_VERSION: "1.25.0"
@@ -577,3 +578,103 @@ jobs:
             --clobber
 
           echo "Updated ${CHANNEL}.json on the 'channels' release"
+
+  # Build and push the telahubd Docker image to ghcr.io. See DESIGN-docker.md
+  # for the tag strategy and the rationale behind not publishing dev-channel
+  # builds. The image is a source build of ./cmd/telahubd layered on
+  # gcr.io/distroless/static-debian12:nonroot (see Dockerfile.telahubd).
+  #
+  # Triggered on beta and stable tags only. Dev builds skip this job so
+  # ghcr.io does not accumulate short-lived tags. Operators who want to
+  # run a dev build via Docker rebuild Dockerfile.telahubd locally from
+  # the dev tag's source.
+  docker-publish:
+    needs: [compute-version, release]
+    if: always() && needs.release.result == 'success'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Determine channel from tag
+        id: channel
+        run: |
+          TAG="${{ needs.compute-version.outputs.tag }}"
+          if [[ "$TAG" =~ -dev\.[0-9]+$ ]]; then
+            CHANNEL="dev"
+          elif [[ "$TAG" =~ -beta\.[0-9]+$ ]]; then
+            CHANNEL="beta"
+          elif [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            CHANNEL="stable"
+          else
+            CHANNEL="dev"
+          fi
+          echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Skip dev builds
+        if: steps.channel.outputs.channel == 'dev'
+        run: |
+          echo "Channel is dev; skipping Docker publish (see DESIGN-docker.md section 12.1)."
+
+      - name: Checkout source
+        if: steps.channel.outputs.channel != 'dev'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.tag || github.ref }}
+
+      - name: Compute image tags
+        if: steps.channel.outputs.channel != 'dev'
+        id: tags
+        run: |
+          IMAGE="ghcr.io/${{ github.repository_owner }}/telahubd"
+          # Normalise the owner to lowercase; ghcr rejects mixed case.
+          IMAGE="${IMAGE,,}"
+          TAG="${{ steps.channel.outputs.tag }}"
+          CHANNEL="${{ steps.channel.outputs.channel }}"
+          TAGS="${IMAGE}:${TAG}"
+          case "$CHANNEL" in
+            beta)
+              TAGS="${TAGS},${IMAGE}:beta"
+              ;;
+            stable)
+              TAGS="${TAGS},${IMAGE}:stable,${IMAGE}:latest"
+              ;;
+          esac
+          echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
+          echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
+          echo "Tags to publish:"
+          echo "$TAGS" | tr ',' '\n' | sed 's/^/  /'
+
+      - name: Set up QEMU
+        if: steps.channel.outputs.channel != 'dev'
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        if: steps.channel.outputs.channel != 'dev'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to ghcr.io
+        if: steps.channel.outputs.channel != 'dev'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        if: steps.channel.outputs.channel != 'dev'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.telahubd
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            TELA_VERSION=${{ steps.channel.outputs.tag }}
+          tags: ${{ steps.tags.outputs.tags }}
+          push: true
+          cache-from: type=registry,ref=${{ steps.tags.outputs.image }}:buildcache
+          cache-to: type=registry,ref=${{ steps.tags.outputs.image }}:buildcache,mode=max
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.channel.outputs.tag }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ patch-level dev builds are too granular to list individually.
 
 ## [Unreleased]
 
+### Added
+- Docker-first distribution for `telahubd`. A new `Dockerfile.telahubd` at the repo root builds the hub from source onto `gcr.io/distroless/static-debian12:nonroot`; the release workflow publishes multi-arch (linux/amd64 + linux/arm64) images to `ghcr.io/paulmooreparks/telahubd` under the `:stable`, `:latest`, `:beta`, and `:v<version>` tags. Dev-channel builds do not publish Docker images to keep the registry tidy; operators who want to run a dev build via Docker rebuild the Dockerfile locally from the dev tag's source.
+- `telahubd health` subcommand that probes `http://127.0.0.1:<port>/.well-known/tela` and exits 0 when healthy. Used by the Docker image's `HEALTHCHECK` directive so `docker ps` reports container health without a shell in the distroless base image.
+- Three copy-paste `docker-compose` templates under `book/src/howto/hub-docker/`: `minimal` (LAN / dev), `caddy` (production with auto-Let's Encrypt), `nginx` (for operators with existing nginx). Each template is a working file plus a fully-written reverse-proxy config (Caddyfile, nginx.conf) with the WebSocket upgrade handling spelled out.
+- Book's hub install chapter rewritten to lead with Docker; the native-binary install is kept intact but demoted to an "alternative" section. Authentication and TLS subsections now call out which steps a Docker install has already handled.
+
+### Fixed
+- `telahubd -config /path/to/file` treats a non-existent file as a first-start signal instead of fatal-erroring during `loadHubConfig`. The bootstrap path (env-var or auto) writes the config to the supplied path on first successful start. Previously a `docker run` against an empty volume crashed immediately; now it bootstraps cleanly.
+- `autoBootstrapAuth` banner now reports where the token was persisted and how to retrieve it later via `telahubd user show-owner`. Previously the banner said "it will not be displayed again" with no follow-up pointer, leaving operators who missed the first boot line without a recovery breadcrumb. Persist failures (unwritable `/data`, permission issues on a bind mount) now log two `WARNING` lines instead of being silently swallowed.
+
 ### Fixed
 - `tela update`, `telad update`, `telahubd update`, the hub admin `POST /api/admin/update` endpoint, the agent `update` mgmt action, and TelaVisor's local-binary install paths now bypass the channel-manifest cache. Previously a 5-minute in-process cache could make an install path read a stale manifest and refuse a freshly-published tag (or, for TV-mediated agent updates, send the agent a version that did not match what the agent saw on its own fetch). Status displays still use the cached path; only the install side fetches fresh.
 

--- a/DESIGN-docker.md
+++ b/DESIGN-docker.md
@@ -1,0 +1,233 @@
+# Docker-first telahubd distribution: design
+
+This document is the authoritative design for [issue #58](https://github.com/paulmooreparks/tela/issues/58), targeting the `0.13` release.
+
+It covers why telahubd (and only telahubd) gets a first-class Docker image, how the image is structured and published, how an operator gets from a fresh host to a running hub, and what the self-update story looks like inside a container. Narrative how-tos for end operators come later as a book chapter; this document speaks to maintainers and integrators.
+
+---
+
+## 1. Motivation
+
+The current hub install page reads as a matrix of operating system by release channel. That shape is right for endpoint-role binaries (`tela`, `telad`) because they bind local ports on the machine they expose and have to coexist with whatever else the user is running there. It is the wrong first impression for a server-role daemon: most operators want to be told "here is the image, run it" and then get on with configuring the reverse proxy.
+
+`telahubd` is an ideal Docker-first candidate:
+
+- Single static Go binary, no native dependencies beyond a CA certificate bundle.
+- Runs as a service on someone else's box, not on the user's laptop.
+- Almost always fronted by a reverse proxy (Caddy, nginx, Cloudflare Tunnel).
+- Upgrade cadence is operator-driven, not end-user-driven. "docker pull and restart" is a natural fit.
+
+`tela` and `telad` are not candidates for a primary Docker path:
+
+- Endpoint-role: they need to bind local ports on the machine they are exposing.
+- `tela` needs DNS setup access for local-name resolution on macOS and Linux.
+- `telad` runs as a system service on Windows and as a systemd unit on Linux; the operating system's service manager is the right packaging.
+- Native binary distribution (`brew`, `apt`, `.msi`, or a plain binary drop) matches how operators already deploy endpoint software.
+
+TelaVisor is also not a candidate: it is a desktop GUI, and a container is not a meaningful distribution format for a GUI.
+
+This design scopes the Docker work for `telahubd` only. Dockerfiles for `telad` may appear later as stretch goals; they are explicitly out of scope here.
+
+## 2. Image architecture
+
+Multi-stage source build. Final image is `gcr.io/distroless/static-debian12:nonroot` with the `telahubd` binary at `/usr/local/bin/telahubd`.
+
+```dockerfile
+FROM golang:1.25-alpine AS build
+# go.mod / go.sum cached as a separate layer
+# go build -ldflags '-s -w -X main.version=$TELA_VERSION' -trimpath
+
+FROM gcr.io/distroless/static-debian12:nonroot
+COPY --from=build /out/telahubd /usr/local/bin/telahubd
+WORKDIR /data
+VOLUME ["/data"]
+EXPOSE 80
+EXPOSE 41820/udp
+ENTRYPOINT ["/usr/local/bin/telahubd"]
+CMD ["-config", "/data/telahubd.yaml"]
+```
+
+Properties:
+
+- `CGO_ENABLED=0`, fully static.
+- Runs as the distroless `nonroot` user (uid 65532). No root inside the container.
+- No shell, no package manager, no writable `/`. `docker exec sh` does not work; if an operator needs that, they must use a one-off debug image.
+- Size around 18 MB. Distroless carries the CA bundle, `/etc/passwd` entries for `nobody` and `nonroot`, and tzdata.
+
+The single binary is the entire payload. Everything telahubd embeds (the hub console, the channel package, the admin API) is already in the compiled binary.
+
+## 3. Tag strategy
+
+Every release from `release.yml` publishes a multi-architecture manifest to `ghcr.io/paulmooreparks/telahubd` with several tags:
+
+| Tag | Points at |
+|---|---|
+| `:dev` | most recent dev build |
+| `:beta` | most recent beta |
+| `:stable` | most recent stable |
+| `:latest` | alias for `:stable` |
+| `:v0.13.0` | specific stable version |
+| `:v0.13.0-beta.1` | specific beta |
+| `:v0.13.0-dev.3` | specific dev build (see 12.1 on whether we publish these at all) |
+
+The mental model for operators matches what they already know from the native channel manifests:
+
+- "Give me the current stable" -> `:stable` or `:latest`.
+- "Pin to a specific version" -> `:v0.13.0`.
+- "Follow dev" -> `:dev`.
+
+The channel-manifest tag strategy maps directly to Docker tags. No new concepts for operators who have already read the release-process chapter.
+
+## 4. Self-update model
+
+Native binaries and Docker containers have different upgrade models, and telahubd honors both.
+
+**Native path:** `telahubd update` fetches the channel manifest, verifies the SHA-256 of the new binary, atomically swaps it into place, and restarts the service. This is what the channel-sources rework (#55) is for.
+
+**Docker path:** operators run `docker pull ghcr.io/paulmooreparks/telahubd:stable` followed by `docker compose up -d telahubd` (or `docker restart tela-telahubd` without compose). The container restarts against the same `/data` volume; telahubd reads the persisted config and carries on. Graceful shutdown (#30, shipped in 0.12) drains in-flight requests via `shutdownTimeout` on SIGTERM, so `docker stop` is clean.
+
+The two paths are parallel, not competing. The channel-manifest system drives native self-update; Docker tags drive Docker updates. `telahubd update` run inside a container is a no-op in practice (the binary lives on a read-only layer) and will eventually be made to detect that context and print a "you are inside a container; use docker pull" message. That is a polish item, not blocking 0.13.
+
+Automated Docker updates (Watchtower, Diun, Argo CD) are out of scope for Tela. Docker-native tooling handles that class of problem better than anything we could bake into the image.
+
+## 5. Publishing pipeline
+
+GitHub Container Registry (`ghcr.io`) is the canonical home. Docker Hub mirror can be added later on demand; GHCR alone is sufficient for 0.13.
+
+`release.yml` gains a `docker-publish` job that runs after the native-binary matrix succeeds:
+
+- `docker/setup-buildx-action@v3`
+- `docker/login-action@v3` using the job's `GITHUB_TOKEN`
+- `docker/build-push-action@v6` with:
+  - `context: .`
+  - `file: Dockerfile.telahubd`
+  - `platforms: linux/amd64,linux/arm64`
+  - `build-args: TELA_VERSION=${tag}`
+  - `tags: <computed set>`
+  - `push: true`
+  - `cache-from: type=registry,ref=ghcr.io/paulmooreparks/telahubd:buildcache`
+  - `cache-to: type=registry,ref=ghcr.io/paulmooreparks/telahubd:buildcache,mode=max`
+
+The tag set is computed in a preceding shell step:
+
+- Always: `:${VERSION}`.
+- If channel is dev: also `:dev` (subject to 12.1).
+- If channel is beta: also `:beta`.
+- If channel is stable: also `:stable` and `:latest`.
+
+Image signing via `cosign` is worth doing later but is out of scope for 0.13. It opens questions about key management, rotation, and downstream verification that deserve their own design.
+
+## 6. First-run bootstrap
+
+The container needs a path from "fresh image pull" to "running hub with an owner token" without manual `docker exec` gymnastics. Three options, in decreasing order of preference:
+
+**Option 1 (recommended): env-var owner token on first start.** Pass `TELA_OWNER_TOKEN=<hex>` to `docker run` or set it in `.env` for `docker compose`. The hub's existing `bootstrapFromEnv` path seeds the owner identity on a blank config and persists it to `/data/telahubd.yaml`. Subsequent restarts honor the persisted token; the env var becomes redundant but harmless.
+
+Preferred because it is one step for the operator, does not require log scraping or a container shell, and fits infrastructure-as-code workflows where the operator generates the token up front and stores it in a secrets manager.
+
+**Option 2: explicit bootstrap via a one-off run.** `docker run --rm -v telahubd-data:/data telahubd:stable user bootstrap` writes the token to the volume and prints it once to stdout. The operator captures the token from the printed line, then starts the server with the same volume. Two-step but explicit and suitable for operators who do not want to generate tokens themselves.
+
+Works because the image's `ENTRYPOINT` is the binary itself, so any subcommand composes through `docker run --rm <image> <subcommand>`.
+
+**Option 3 (fallback): auto-bootstrap on first start.** If no config file exists and no `TELA_OWNER_TOKEN` env var is set, telahubd's `autoBootstrapAuth` generates an owner token, writes it to `/data/telahubd.yaml`, and logs a line identifying the token. The operator reads it from `docker logs` before the container is recycled.
+
+Workable but awkward. If the first start happened while the operator was configuring something else and the log line scrolled past, recovery is `docker exec <container> telahubd user show-owner`, which requires a shell the distroless image does not provide. Operators in this situation must use a debug image variant or recreate the container with the env-var path.
+
+All three paths stay functional. The book and the compose templates default to option 1. Option 3 exists as a safety net; it is not the recommended path.
+
+This design does require one small fix to the foreground-mode Main() path: `-config <file>` where `<file>` does not exist must be treated as a first-start signal (carry the path forward so bootstrap writes there) rather than a fatal error. Pre-#58, running the CMD with an empty volume hit `log.Fatalf` during `loadHubConfig`. Fixed as part of Phase 1.
+
+## 7. State layout
+
+`/data` is the persistent state directory. Contents once the hub is running:
+
+- `telahubd.yaml` -- the config file: auth tokens, portal registrations, channels config, bridges, shutdown timeout.
+- Implementation detail: the history ring buffer is currently in-memory only and does not land on disk. A future release may spill it to `/data/history/`; the volume accommodates that already.
+
+Mount options:
+
+- **Named volume (recommended):** `docker volume create telahubd-data` and then `-v telahubd-data:/data`. Docker's volume init copies the image's directory ownership (uid 65532) onto the volume, so writes from the nonroot user work out of the box.
+- **Bind mount** (for operators who want to edit `telahubd.yaml` on the host): `-v /srv/telahubd:/data`. The host directory must be readable and writable by uid 65532. The book documents `sudo install -d -o 65532 -g 65532 /srv/telahubd` as the one-time setup step.
+
+What survives container recreation: everything in `/data` if the volume is reused. In-memory state (session list, live agent WebSockets, the history ring buffer) does not survive, which is by design. telahubd is restart-safe; agents reconnect within seconds and clients retry.
+
+## 8. Ports and the UDP gotcha
+
+Two ports, both expose with care:
+
+- **80 (HTTP + WebSocket):** fronted by a reverse proxy in production. The compose templates show Caddy and nginx configurations. For a local LAN test, `-p 8080:80` with direct connection works fine.
+- **41820/udp (UDP relay):** must carry the `/udp` suffix on `docker run -p`. Without it, Docker exposes only the TCP side, which telahubd does not listen on, and the entire UDP relay tier silently fails to work. All relay traffic falls back to WebSocket-over-TCP. The hub still functions, but latency roughly doubles and throughput is cut in half on sessions that would otherwise hole-punch to UDP.
+
+This is the single most likely misconfiguration. Every Docker example in the book, every compose template, and every `docker run` line includes the `/udp` suffix. The troubleshooting section gains an entry titled "My agents all fall back to WebSocket relay" that says to check this first.
+
+A future enhancement can have telahubd log a warning when it detects UDP is unreachable (e.g. port is bound but the listening socket never sees packets during the first five minutes of uptime). Out of scope for 0.13; filed as a follow-up if the workaround proves insufficient.
+
+TLS termination is the reverse proxy's job. `telahubd` does not terminate TLS itself. Every production compose template puts a proxy in front. A "no proxy, unencrypted, direct-to-hub" template is not provided; it would only get copy-pasted into production.
+
+## 9. Compose topology
+
+Four templates under `book/src/howto/hub-docker/`:
+
+**`docker-compose.minimal.yml`** -- telahubd alone on port 80. For LAN-only dev or test deployments. Demonstrates env-var bootstrap, a named volume, and the UDP port mapping. No proxy, no TLS.
+
+**`docker-compose.caddy.yml`** -- telahubd plus Caddy. Caddy's config is a three-line snippet that reverse-proxies `https://hub.example.com` to `telahubd:80` with automatic Let's Encrypt. Recommended for production deployments where the operator owns the domain and can point DNS at the Docker host. UDP port is published directly from telahubd to the host; Caddy only handles TCP.
+
+**`docker-compose.nginx.yml`** -- telahubd plus nginx. For operators who already run nginx. Provides a ready-to-paste config with the WebSocket upgrade headers spelled out (`Connection: upgrade`, `Upgrade: $http_upgrade`, `proxy_read_timeout 86400s`). These are easy to get wrong, and the template removes the guesswork.
+
+**`docker-compose.full.yml`** -- telahubd plus Caddy plus Awan Saya portal. One-box deployment for operators who want the portal colocated with the hub. The AS service runs on its own domain; Caddy terminates both. Volume layout keeps the three services' state separate so any one of them can be rebuilt without touching the others.
+
+Each template is a working file: `docker compose up -d` against it, with a populated `.env`, produces a running hub. The book walks an operator through each of the four scenarios.
+
+## 10. Install-page rewrite
+
+`book/src/howto/hub.md` is restructured around the deployment model rather than the binary distribution format:
+
+1. "Docker" is the primary path. The first thing a hub operator sees.
+2. Native installation becomes an "Alternative: native binary" section further down, aimed at operators who cannot or do not want to run Docker.
+3. The existing OS-by-channel matrix is preserved in the native section; no content is deleted, only reordered and re-weighted.
+
+The book's landing page and the repo README get a matching one-line adjustment pointing Docker operators at the new chapter.
+
+## 11. Non-goals
+
+- **Dockerizing `tela` or `telad` as a primary distribution path.** Both remain native. A community-contributed Dockerfile.telad for operators running agents alongside containerized services is a reasonable stretch goal for a later release.
+- **Dockerizing TelaVisor.** Desktop GUI. Package-manager distribution (DMG, MSI, AppImage) is the right answer.
+- **Image signing via cosign.** Separate design; key management, rotation, and downstream verification all deserve explicit choices. Worth doing, not in 0.13.
+- **Docker Hub mirror.** GHCR is sufficient. Can be added later without any protocol change if demand materializes.
+- **Bundling the channel-manifest self-update path into the Docker flow.** The two distribution channels remain parallel. Operators who deploy via Docker use `docker pull`; operators who deploy native binaries use `telahubd update`.
+
+## 12. Open questions
+
+### 12.1 Do dev-channel builds publish a Docker image at all?
+
+Every commit to `main` cuts a `v0.13.0-dev.N` tag via `release.yml`. Publishing a Docker image for every dev build means `ghcr.io` accumulates short-lived tags forever. Three approaches:
+
+- **Publish only for beta and stable.** `:dev` floats to a periodic snapshot (daily, or on a manual trigger). Simplest.
+- **Publish for every dev build but auto-prune old dev tags.** Keep the last 10 dev tags; drop older ones via a GHCR cleanup action. Preserves the ability to pin to a specific dev build but keeps the registry tidy.
+- **Publish only when the release workflow's tag push matches `-dev.*` and the commit message carries a `docker` label.** Opt-in per-commit. More control, more operator friction.
+
+Recommend the first approach unless dogfooding against `dev` via Docker becomes a real use case. For dev dogfooding on native hosts, the channel-manifest flow already works; Docker does not add much.
+
+### 12.2 Healthcheck shape
+
+Dockerfile can `HEALTHCHECK`. Simplest would be `curl -fsSL http://localhost/.well-known/tela`, but distroless has no `curl`. Three options:
+
+- Add a `telahubd health` subcommand that returns 0 if the local hub responds to `/.well-known/tela`, 1 otherwise. About fifteen lines of Go, keeps the image self-contained.
+- No healthcheck in the image; operators add one at compose level with a sidecar.
+- Bake a tiny `wget` static binary into a runtime layer. Bloats the image.
+
+Recommend the first approach. Cleanest, no external dependencies, works under any orchestrator that honors `HEALTHCHECK`.
+
+### 12.3 Signal handling under distroless
+
+distroless has no init system. `telahubd` runs as PID 1. Go's runtime forwards signals via `signal.Notify`, so `docker stop` delivers SIGTERM correctly. Zombie reaping is not an issue because telahubd does not fork. No `tini` or similar required.
+
+Verified on the Phase 1 smoke test; called out here so no one gets clever about adding init wrappers later.
+
+### 12.4 TelaVisor connecting to a Dockerized hub
+
+Expected to work unchanged. TV talks HTTPS through whatever reverse proxy sits in front of the hub; the hub's backing binary being a container instead of a native process is invisible. Confirm during Phase 4 testing that the full operator walkthrough (TV -> Caddy -> telahubd -> agent) works end to end with no TV-side code changes.
+
+### 12.5 Logging
+
+telahubd logs to stderr. Docker captures both stdout and stderr into the container log stream. No changes required. Noted here so no one files a bug that says "logs should go to stdout" and gets it merged without this context.

--- a/DESIGN-docker.md
+++ b/DESIGN-docker.md
@@ -166,17 +166,17 @@ TLS termination is the reverse proxy's job. `telahubd` does not terminate TLS it
 
 ## 9. Compose topology
 
-Four templates under `book/src/howto/hub-docker/`:
+Three templates under `book/src/howto/hub-docker/`:
 
 **`docker-compose.minimal.yml`** -- telahubd alone on port 80. For LAN-only dev or test deployments. Demonstrates env-var bootstrap, a named volume, and the UDP port mapping. No proxy, no TLS.
 
-**`docker-compose.caddy.yml`** -- telahubd plus Caddy. Caddy's config is a three-line snippet that reverse-proxies `https://hub.example.com` to `telahubd:80` with automatic Let's Encrypt. Recommended for production deployments where the operator owns the domain and can point DNS at the Docker host. UDP port is published directly from telahubd to the host; Caddy only handles TCP.
+**`docker-compose.caddy.yml`** -- telahubd plus Caddy. Caddy's config reverse-proxies `https://hub.example.com` to `telahubd:80` with automatic Let's Encrypt. Recommended for production deployments where the operator owns the domain and can point DNS at the Docker host. UDP port is published directly from telahubd to the host; Caddy only handles TCP.
 
-**`docker-compose.nginx.yml`** -- telahubd plus nginx. For operators who already run nginx. Provides a ready-to-paste config with the WebSocket upgrade headers spelled out (`Connection: upgrade`, `Upgrade: $http_upgrade`, `proxy_read_timeout 86400s`). These are easy to get wrong, and the template removes the guesswork.
+**`docker-compose.nginx.yml`** -- telahubd plus nginx. For operators who already run nginx. Provides a ready-to-paste config with the WebSocket upgrade-header map and the idle-timeout bump that long-lived agent connections need. Certificates are brought by the operator (host-level certbot, cert-manager, etc.); nginx does not issue its own.
 
-**`docker-compose.full.yml`** -- telahubd plus Caddy plus Awan Saya portal. One-box deployment for operators who want the portal colocated with the hub. The AS service runs on its own domain; Caddy terminates both. Volume layout keeps the three services' state separate so any one of them can be rebuilt without touching the others.
+Each template is a working file: `docker compose up -d` against it, with a populated `.env`, produces a running hub.
 
-Each template is a working file: `docker compose up -d` against it, with a populated `.env`, produces a running hub. The book walks an operator through each of the four scenarios.
+A fourth template, `docker-compose.full.yml` -- telahubd plus Caddy plus Awan Saya portal as one-box deployment -- was originally planned and is filed as a follow-up. It waits on Awan Saya publishing an image to a container registry; today AS deploys via its own `docker-compose.yml` from the `awansaya` repo. Once an AS image lands on ghcr.io the fourth template becomes a 20-line addition to this directory.
 
 ## 10. Install-page rewrite
 

--- a/Dockerfile.telahubd
+++ b/Dockerfile.telahubd
@@ -97,8 +97,16 @@ VOLUME ["/data"]
 EXPOSE 80
 EXPOSE 41820/udp
 
+# HEALTHCHECK uses the binary itself (the distroless base has no curl or
+# wget). `telahubd health` probes http://127.0.0.1:80/.well-known/tela
+# and exits 0 when the hub is serving. See DESIGN-docker.md section 12.2
+# for why we add a subcommand instead of baking in wget-static.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD ["/usr/local/bin/telahubd", "health"]
+
 # Default command runs the hub. Override with subcommands as needed:
 #   docker run --rm telahubd user bootstrap
 #   docker run --rm telahubd channels publish -channel local -tag vX.Y.Z
+#   docker run --rm telahubd health
 ENTRYPOINT ["/usr/local/bin/telahubd"]
 CMD ["-config", "/data/telahubd.yaml"]

--- a/Dockerfile.telahubd
+++ b/Dockerfile.telahubd
@@ -1,0 +1,104 @@
+# Dockerfile.telahubd -- Tela hub server image.
+#
+# Multi-stage build that compiles telahubd from this repo and packages
+# it on a distroless/static base. Final image is around 25 MB and runs
+# as a non-root user.
+#
+# Build:
+#   docker build -f Dockerfile.telahubd -t telahubd:dev .
+#
+# Run (with bootstrap owner token; see "First-run" below for alternatives):
+#   docker run --rm \
+#     -p 80:80 \
+#     -p 41820:41820/udp \
+#     -e TELA_OWNER_TOKEN=$(openssl rand -hex 32) \
+#     -v telahubd-data:/data \
+#     telahubd:dev
+#
+# Notes:
+#
+#   - The TELAHUBD_PORT default is 80; remap with -p HOST:80 if you
+#     need a different host port.
+#   - The UDP relay port MUST be published with the /udp suffix
+#     (-p 41820:41820/udp). Without /udp, Docker exposes only the TCP
+#     side and the entire UDP relay tier silently fails to work; the
+#     hub falls back to WebSocket and operators wonder why their
+#     latency is awful.
+#   - /data is the persistent state directory: telahubd.yaml, history
+#     ring buffer, generated tokens. Mount a named volume or bind mount
+#     here so config and tokens survive container recreation.
+#   - The image runs as a non-root user (uid 65532, "nonroot" in the
+#     distroless image). Bind-mounted host directories must be readable
+#     and writable by that uid.
+#
+# First-run bootstrap (see book/src/howto/hub.md for details):
+#
+#   1. TELA_OWNER_TOKEN=<hex> on `docker run` -- preferred. The hub
+#      seeds the owner identity from the env var on a blank config and
+#      persists it; subsequent restarts use the persisted token.
+#   2. `docker run --rm telahubd user bootstrap` against a volume-
+#      mounted config dir to write the token, then start the server
+#      with the same volume. Two-step but explicit.
+#   3. Auto-bootstrap on first start (no env var, no prior config):
+#      telahubd generates an owner token and prints it to stdout
+#      exactly once. Capture it from `docker logs` immediately or you
+#      will have to do `user show-owner` later from inside the
+#      container.
+
+# ── Stage 1: build ──────────────────────────────────────────────────
+FROM golang:1.25-alpine AS build
+
+# git is required for go modules that resolve via VCS.
+RUN apk add --no-cache git
+
+WORKDIR /src
+
+# Cache module downloads as a separate layer so source-only edits
+# don't force a fresh `go mod download` on every build.
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Bring in the rest of the source.
+COPY . .
+
+# Build telahubd as a fully static binary. CGO is off by default with
+# alpine + musl, but spell it out and -ldflags '-w -s' to drop the
+# debug tables.
+ARG TELA_VERSION=dev
+ENV CGO_ENABLED=0
+ENV GOFLAGS=-trimpath
+RUN go build \
+    -ldflags="-s -w -X main.version=${TELA_VERSION}" \
+    -o /out/telahubd \
+    ./cmd/telahubd
+
+# ── Stage 2: runtime ────────────────────────────────────────────────
+FROM gcr.io/distroless/static-debian12:nonroot
+
+ARG TELA_VERSION=dev
+LABEL org.opencontainers.image.title="telahubd" \
+      org.opencontainers.image.description="Tela hub server (telahubd) -- HTTP/WebSocket signalling, UDP relay, optional self-hosted release channel server." \
+      org.opencontainers.image.version="${TELA_VERSION}" \
+      org.opencontainers.image.source="https://github.com/paulmooreparks/tela" \
+      org.opencontainers.image.licenses="MIT"
+
+# Single static binary, copied to a path on the default PATH inside
+# distroless. The container's USER is "nonroot" (uid 65532) inherited
+# from the base image.
+COPY --from=build /out/telahubd /usr/local/bin/telahubd
+
+# Default state directory. The image's nonroot user owns it after
+# `docker volume create` thanks to Docker's volume init copying the
+# image's directory ownership; bind mounts from a host path need the
+# operator to chown to 65532 first.
+WORKDIR /data
+VOLUME ["/data"]
+
+EXPOSE 80
+EXPOSE 41820/udp
+
+# Default command runs the hub. Override with subcommands as needed:
+#   docker run --rm telahubd user bootstrap
+#   docker run --rm telahubd channels publish -channel local -tag vX.Y.Z
+ENTRYPOINT ["/usr/local/bin/telahubd"]
+CMD ["-config", "/data/telahubd.yaml"]

--- a/book/src/howto/hub-docker/.env.example
+++ b/book/src/howto/hub-docker/.env.example
@@ -1,0 +1,45 @@
+# Copy to .env and fill in values for your hub.
+#
+# Docker Compose reads .env automatically when you run `docker compose
+# -f docker-compose.<flavor>.yml up -d` from this directory. Do NOT
+# commit the populated .env to any public repository -- it contains
+# your hub's owner token.
+#
+# Three flavors of compose file in this directory use a different
+# subset of these variables:
+#
+#   docker-compose.minimal.yml  -- TELA_OWNER_TOKEN, TELAHUBD_NAME,
+#                                  TELAHUBD_UDP_HOST
+#   docker-compose.caddy.yml    -- +HUB_DOMAIN
+#   docker-compose.nginx.yml    -- TELA_OWNER_TOKEN, TELAHUBD_NAME,
+#                                  TELAHUBD_UDP_HOST  (domain lives
+#                                  in nginx.conf, not here)
+
+# Owner token: a long random hex string. Generate one of:
+#   openssl rand -hex 32
+#   python3 -c 'import secrets; print(secrets.token_hex(32))'
+#
+# This becomes the first-owner identity the hub boots with. Operators
+# who prefer to have the hub generate one automatically can leave
+# this blank; the token will appear in `docker logs telahubd` once,
+# and `telahubd user show-owner` retrieves it afterwards.
+TELA_OWNER_TOKEN=
+
+# Display name for the hub. Appears in TelaVisor, portal directories,
+# and the admin console. Optional but recommended.
+TELAHUBD_NAME=my-hub
+
+# Domain name that clients reach this hub at. Used only by the Caddy
+# compose file; Caddy issues a Let's Encrypt certificate for this
+# hostname on first start.
+HUB_DOMAIN=hub.example.com
+
+# Hostname or IP the UDP relay reports in its udp-offer message.
+# Clients STUN-detect their reflexive address and try to hole-punch
+# directly to this value on 41820/udp.
+#
+# Leave blank on a LAN. On the public internet set to the hub's
+# publicly-reachable address. This MUST NOT be a Cloudflare-proxied
+# hostname or any other TCP-only front-end; UDP does not traverse
+# those. A direct A record pointing at the Docker host is correct.
+TELAHUBD_UDP_HOST=

--- a/book/src/howto/hub-docker/Caddyfile
+++ b/book/src/howto/hub-docker/Caddyfile
@@ -1,0 +1,31 @@
+# Caddyfile for the telahubd + Caddy docker-compose.
+#
+# Caddy auto-issues a Let's Encrypt certificate for HUB_DOMAIN on
+# first startup and renews it in the background. reverse_proxy
+# handles both plain HTTP requests and WebSocket upgrades without
+# any extra directives; Caddy detects the Upgrade header and swaps
+# to the WebSocket transport automatically.
+#
+# The one non-default worth knowing: idle WebSocket connections from
+# agents stay open indefinitely. Caddy's default read/write timeout
+# is one minute, which would cut off connected agents every minute.
+# `flush_interval -1` disables the response buffer so messages land
+# as soon as they arrive; more importantly the `transport http`
+# block raises the upstream idle timeout.
+
+{$HUB_DOMAIN} {
+    reverse_proxy telahubd:80 {
+        # Long-lived WebSocket connections from agents and clients
+        # should not be interrupted by Caddy's default timeouts.
+        flush_interval -1
+
+        transport http {
+            # Hub sends keepalive frames every 25 seconds; anything
+            # well above that keeps idle tunnels alive forever.
+            dial_timeout 5s
+            response_header_timeout 30s
+            read_timeout 1h
+            write_timeout 1h
+        }
+    }
+}

--- a/book/src/howto/hub-docker/README.md
+++ b/book/src/howto/hub-docker/README.md
@@ -1,0 +1,53 @@
+# Docker Compose templates for telahubd
+
+Copy-paste starting points for running `telahubd` in Docker. Pick the
+file that matches your deployment topology, fill in `.env`, run
+`docker compose up -d`, and you are done.
+
+## Files in this directory
+
+| File | Topology |
+|------|----------|
+| `docker-compose.minimal.yml` | telahubd alone on port 80. LAN / dev only. No TLS. |
+| `docker-compose.caddy.yml` | telahubd + [Caddy](https://caddyserver.com) reverse proxy with automatic Let's Encrypt. Recommended for production. |
+| `docker-compose.nginx.yml` | telahubd + nginx. For operators who already run nginx. Bring your own certs. |
+| `Caddyfile` | Companion config for the Caddy template. |
+| `nginx.conf` | Companion config for the nginx template. Includes the WebSocket upgrade handling. |
+| `.env.example` | Template for `.env`. Copy to `.env` and fill in at least `TELA_OWNER_TOKEN`. |
+
+Every template uses the same image (`ghcr.io/paulmooreparks/telahubd:stable`)
+and the same `telahubd-data` named volume for config and tokens, so
+switching between topologies is a matter of editing the compose file
+you use -- the persistent state carries over unchanged.
+
+## The single most-missed gotcha: UDP
+
+Every one of these compose files publishes UDP port `41820` with the
+`/udp` suffix:
+
+```yaml
+ports:
+  - "41820:41820/udp"
+```
+
+Without the suffix, Docker exposes only the TCP side. telahubd does
+not listen on TCP 41820, so the mapping silently does nothing, and
+every relay session falls back to WebSocket-over-TCP. The hub keeps
+working but round-trip latency roughly doubles.
+
+If you adapt one of these templates and sessions feel slow,
+`docker port <container-name>` should report `41820/udp`. If it
+reports `41820/tcp` instead, you lost the suffix.
+
+## Upgrading
+
+Docker-based upgrades use `docker pull`, not `telahubd update`:
+
+```sh
+docker compose pull
+docker compose up -d
+```
+
+Named volumes survive container recreation, so config and tokens are
+preserved. See the top-level book chapter on the release process for
+the channel tag model and how to pin to a specific version.

--- a/book/src/howto/hub-docker/docker-compose.caddy.yml
+++ b/book/src/howto/hub-docker/docker-compose.caddy.yml
@@ -1,0 +1,67 @@
+# telahubd + Caddy: production-grade single-box deployment.
+#
+# Caddy terminates TLS, handles automatic Let's Encrypt issuance and
+# renewal, and reverse-proxies HTTP + WebSocket to telahubd over the
+# internal Docker network. telahubd exposes its HTTP port only to
+# Caddy; the UDP relay port goes direct from the host to telahubd
+# because Caddy is a TCP-only proxy and cannot forward UDP.
+#
+# Usage:
+#   1. Point an A record at this host. Set HUB_DOMAIN in .env.
+#   2. Open firewall ports 80/tcp, 443/tcp, 41820/udp.
+#   3. Copy .env.example to .env and fill in at least HUB_DOMAIN
+#      and TELA_OWNER_TOKEN.
+#   4. docker compose -f docker-compose.caddy.yml up -d
+#   5. Caddy takes about a minute to issue the cert on first start.
+#      `docker compose logs caddy` confirms when it lands.
+
+services:
+  caddy:
+    image: caddy:2-alpine
+    container_name: caddy
+    restart: unless-stopped
+
+    ports:
+      - "80:80"     # Let's Encrypt HTTP-01 challenge + 301 to HTTPS
+      - "443:443"   # Hub HTTPS + WebSocket
+
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data        # issued certs + account keys
+      - caddy-config:/config    # Caddy's managed state
+
+    environment:
+      # Surfaced to the Caddyfile as {$HUB_DOMAIN}.
+      - HUB_DOMAIN=${HUB_DOMAIN}
+
+    depends_on:
+      - telahubd
+
+  telahubd:
+    image: ghcr.io/paulmooreparks/telahubd:stable
+    container_name: telahubd
+    restart: unless-stopped
+
+    # HTTP port is NOT published on the host; only Caddy talks to
+    # telahubd:80 over the internal network. UDP relay port IS
+    # published on the host (Caddy cannot proxy UDP). The /udp
+    # suffix is REQUIRED -- omitting it loses the UDP relay tier.
+    ports:
+      - "41820:41820/udp"
+
+    environment:
+      - TELA_OWNER_TOKEN=${TELA_OWNER_TOKEN:-}
+      - TELAHUBD_NAME=${TELAHUBD_NAME:-}
+      # Set to the public hostname or IP that agents / clients
+      # reach the UDP relay at. Usually the same domain as
+      # HUB_DOMAIN, but UDP has to dodge any CDN or proxy that
+      # sits in front of the TLS path.
+      - TELAHUBD_UDP_HOST=${TELAHUBD_UDP_HOST:-${HUB_DOMAIN}}
+
+    volumes:
+      - telahubd-data:/data
+
+volumes:
+  telahubd-data:
+  caddy-data:
+  caddy-config:

--- a/book/src/howto/hub-docker/docker-compose.minimal.yml
+++ b/book/src/howto/hub-docker/docker-compose.minimal.yml
@@ -1,0 +1,54 @@
+# telahubd-minimal.yml -- smallest viable Docker deployment.
+#
+# One service. Port 80 directly exposed. No reverse proxy, no TLS.
+# Suitable for LAN-only dev and test. Do NOT run this on the public
+# internet; operators publishing a hub to the open web must front it
+# with Caddy (docker-compose.caddy.yml) or nginx (docker-compose.nginx.yml)
+# for TLS termination and origin logging.
+#
+# Usage:
+#   1. Copy .env.example to .env and fill in TELA_OWNER_TOKEN.
+#   2. docker compose -f docker-compose.minimal.yml up -d
+#   3. On a workstation: tela login http://<host>  (http, not https)
+#      and paste the token from .env when prompted.
+
+services:
+  telahubd:
+    image: ghcr.io/paulmooreparks/telahubd:stable
+    container_name: telahubd
+    restart: unless-stopped
+
+    ports:
+      # HTTP + WebSocket. Remap the host side if port 80 is taken.
+      - "80:80"
+      # UDP relay. The /udp suffix is REQUIRED. Without it Docker
+      # exposes only the TCP side; the UDP relay tier silently fails
+      # and every session falls back to slower WebSocket transport.
+      - "41820:41820/udp"
+
+    environment:
+      # Bootstrap owner token. Generate with `openssl rand -hex 32`.
+      # If unset, telahubd auto-generates one on first start and
+      # prints it in `docker logs`; see section 6 of DESIGN-docker.md.
+      - TELA_OWNER_TOKEN=${TELA_OWNER_TOKEN:-}
+
+      # Display name for this hub. Appears in TelaVisor sidebars and
+      # portal listings. Defaults to empty (unnamed).
+      - TELAHUBD_NAME=${TELAHUBD_NAME:-}
+
+      # Public hostname or IP for the UDP relay path. Clients STUN-
+      # detect their reflexive address and try to hole-punch directly
+      # to this value on 41820/udp. Must NOT go through any TCP proxy
+      # (Cloudflare, ngrok, Caddy) -- those do not forward UDP.
+      # Leave blank on LAN; set to the host's reachable IP or DNS
+      # name in any non-trivial network.
+      - TELAHUBD_UDP_HOST=${TELAHUBD_UDP_HOST:-}
+
+    volumes:
+      # Persistent state: telahubd.yaml with auth tokens, portal
+      # registrations, hub identity. Named volume keeps ownership
+      # right for the image's nonroot user (uid 65532).
+      - telahubd-data:/data
+
+volumes:
+  telahubd-data:

--- a/book/src/howto/hub-docker/docker-compose.nginx.yml
+++ b/book/src/howto/hub-docker/docker-compose.nginx.yml
@@ -1,0 +1,63 @@
+# telahubd + nginx: for operators who already run nginx.
+#
+# Unlike the Caddy template, nginx does NOT issue its own TLS certs.
+# This compose file assumes certificates are provisioned separately
+# (typically via host-level certbot, cert-manager in Kubernetes, or
+# whatever your stack already does) and bind-mounted into nginx.
+#
+# The nginx.conf in this directory includes the correct WebSocket
+# upgrade-header incantations, which are easy to get wrong. Copy the
+# snippet into an existing nginx deployment if you'd rather integrate
+# than run nginx in a container.
+#
+# Usage:
+#   1. Provision TLS certs for your hub's domain. If you use
+#      certbot on the host:
+#        sudo certbot certonly --standalone -d hub.example.com
+#      and the certs end up at /etc/letsencrypt/live/hub.example.com/.
+#   2. Edit nginx.conf in this directory: replace
+#      `your-hub-domain.example.com` with your actual domain.
+#   3. Copy .env.example to .env and fill in TELA_OWNER_TOKEN.
+#   4. Open firewall ports 80/tcp, 443/tcp, 41820/udp.
+#   5. docker compose -f docker-compose.nginx.yml up -d
+
+services:
+  nginx:
+    image: nginx:alpine
+    container_name: nginx
+    restart: unless-stopped
+
+    ports:
+      - "80:80"
+      - "443:443"
+
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+      # Bring your own certs. Host path must contain
+      # live/<domain>/fullchain.pem and privkey.pem.
+      - /etc/letsencrypt:/etc/letsencrypt:ro
+
+    depends_on:
+      - telahubd
+
+  telahubd:
+    image: ghcr.io/paulmooreparks/telahubd:stable
+    container_name: telahubd
+    restart: unless-stopped
+
+    # Same shape as the Caddy template: nginx talks to telahubd:80
+    # over the internal network, UDP relay goes direct from the host.
+    # The /udp suffix is REQUIRED.
+    ports:
+      - "41820:41820/udp"
+
+    environment:
+      - TELA_OWNER_TOKEN=${TELA_OWNER_TOKEN:-}
+      - TELAHUBD_NAME=${TELAHUBD_NAME:-}
+      - TELAHUBD_UDP_HOST=${TELAHUBD_UDP_HOST:-}
+
+    volumes:
+      - telahubd-data:/data
+
+volumes:
+  telahubd-data:

--- a/book/src/howto/hub-docker/nginx.conf
+++ b/book/src/howto/hub-docker/nginx.conf
@@ -1,0 +1,82 @@
+# nginx.conf for the telahubd + nginx docker-compose.
+#
+# Drop-in replacement for /etc/nginx/nginx.conf in the nginx:alpine
+# image. Operators integrating with an existing nginx can copy just
+# the server {} block and the $connection_upgrade map.
+#
+# Two non-obvious pieces worth keeping:
+#
+#  1. The $connection_upgrade map. nginx does NOT populate
+#     $connection_upgrade on its own; it must be defined explicitly.
+#     Without this, WebSocket upgrades fail and every agent falls
+#     back to polling.
+#
+#  2. proxy_read_timeout: default 60s cuts off long-lived agent
+#     WebSockets. 1 hour comfortably accommodates the hub's 25s
+#     keepalive without masking real failures.
+
+worker_processes auto;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    # Map the client's Upgrade header to the connection-upgrade header
+    # the upstream expects. Required for any WebSocket reverse proxy.
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        ''      close;
+    }
+
+    # Standard access log shape; tune per your logging stack.
+    log_format main '$remote_addr - $remote_user [$time_local] '
+                    '"$request" $status $body_bytes_sent '
+                    '"$http_referer" "$http_user_agent"';
+    access_log /var/log/nginx/access.log main;
+    error_log  /var/log/nginx/error.log warn;
+
+    sendfile on;
+    keepalive_timeout 65;
+
+    # Replace with your actual hub domain before deploying.
+    server {
+        listen 443 ssl;
+        http2 on;
+        server_name your-hub-domain.example.com;
+
+        ssl_certificate     /etc/letsencrypt/live/your-hub-domain.example.com/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/your-hub-domain.example.com/privkey.pem;
+
+        # Long-lived agent WebSockets. Hub keepalive is 25s.
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+
+        location / {
+            proxy_pass http://telahubd:80;
+            proxy_http_version 1.1;
+
+            # WebSocket upgrade headers.
+            proxy_set_header Upgrade    $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+
+            # Standard forwarded-for chain.
+            proxy_set_header Host              $host;
+            proxy_set_header X-Real-IP         $remote_addr;
+            proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            # Do not buffer responses; matters for long-polled admin
+            # endpoints and for Server-Sent-Events if any endpoint
+            # adopts them in the future.
+            proxy_buffering off;
+        }
+    }
+
+    # Redirect plain HTTP to HTTPS.
+    server {
+        listen 80;
+        server_name your-hub-domain.example.com;
+        return 301 https://$host$request_uri;
+    }
+}

--- a/book/src/howto/hub.md
+++ b/book/src/howto/hub.md
@@ -8,23 +8,137 @@ Every agent and every client in your Tela deployment points at this hub. They co
 
 By the end of this chapter you will have:
 
-- `telahubd` running as a managed OS service
-- A reverse proxy of your choice terminating TLS on port 443 (or a direct deployment without a proxy)
+- `telahubd` running either as a Docker container (recommended) or as a managed OS service
+- A reverse proxy terminating TLS on port 443, typically Caddy with an auto-issued Let's Encrypt certificate
 - An owner token secured and ready to use for administration
-- Optionally, a UDP relay port open for faster tunnels
+- UDP port 41820 open for faster tunnels (optional but worth doing)
 - Optionally, the hub registered with a portal directory so clients can find it by name
 
-The hub's public URL will be `wss://hub.example.com`. Agents use that URL in their `telad.yaml`. Clients use it in their connection profiles. Nothing else needs to change when you add new machines, they all find the hub the same way.
+The hub's public URL will be `wss://hub.example.com`. Agents use that URL in their `telad.yaml`. Clients use it in their connection profiles. Nothing else needs to change when you add new machines; they all find the hub the same way.
 
-This chapter takes you from "I ran through the [First connection](../getting-started/first-connection.md) walkthrough" to a production-grade deployment with TLS, authentication, and a service manager.
+This chapter takes you from "I ran through the [First connection](../getting-started/first-connection.md) walkthrough" to a production-grade deployment with TLS, authentication, and a supervisor (Docker or the OS service manager) that keeps the hub running.
 
 ## Hub server: `telahubd`
 
 `telahubd` is the Go-native hub server. Single binary, no runtime dependencies. It serves HTTP, WebSocket relay, and UDP relay on one process.
 
-### Install (bare-metal)
+Two install paths are supported. Pick whichever suits the host.
 
-Pre-built binaries for Windows, Linux, and macOS are available on the [GitHub Releases](https://github.com/paulmooreparks/tela/releases) page.
+- **Docker (recommended).** `docker compose up -d` with one of the ready-made templates. TLS via Caddy with automatic Let's Encrypt, three commands from a fresh VM to a running hub with a valid certificate. This is the default path the chapter walks through.
+- **Native binary (alternative).** Download, install as an OS service, register with the service manager. Still fully supported and appropriate for operators who cannot or do not want to run Docker.
+
+### Install: Docker (recommended)
+
+Prerequisites: Docker Engine and Docker Compose plugin. Any modern Docker install ships both; `docker compose version` confirms the plugin is present.
+
+This walkthrough deploys the Caddy-fronted production template from `book/src/howto/hub-docker/`. Caddy terminates TLS with an auto-issued Let's Encrypt certificate; telahubd runs behind it on the internal Docker network; the UDP relay port is published directly from the host to telahubd because Caddy is TCP-only.
+
+#### Step 1. Point DNS
+
+Point an `A` record for your hub's hostname (for example `hub.example.com`) at the Docker host's public IP. Let's Encrypt needs this to resolve correctly before it will issue the certificate; if DNS is wrong, the first `docker compose up` appears to hang on the Caddy logs at the ACME challenge step.
+
+#### Step 2. Open firewall ports
+
+Three inbound ports on the Docker host:
+
+| Port | Protocol | Purpose |
+|------|----------|---------|
+| 80 | TCP | Let's Encrypt HTTP-01 challenge and the 301 to HTTPS. Caddy can be switched to DNS-01 if port 80 must stay closed; see the Caddy docs. |
+| 443 | TCP | Hub HTTPS and WebSocket. |
+| 41820 | UDP | UDP relay tier. See "The UDP gotcha" below. |
+
+#### Step 3. Pull the compose template
+
+Three templates live under [`book/src/howto/hub-docker/`](hub-docker/) in the repo. For the Caddy-fronted production setup:
+
+```bash
+mkdir -p /srv/telahubd && cd /srv/telahubd
+curl -Lo docker-compose.yml   https://raw.githubusercontent.com/paulmooreparks/tela/main/book/src/howto/hub-docker/docker-compose.caddy.yml
+curl -Lo Caddyfile             https://raw.githubusercontent.com/paulmooreparks/tela/main/book/src/howto/hub-docker/Caddyfile
+curl -Lo .env.example          https://raw.githubusercontent.com/paulmooreparks/tela/main/book/src/howto/hub-docker/.env.example
+cp .env.example .env
+```
+
+#### Step 4. Fill in `.env`
+
+Edit `.env` and set at least two values:
+
+```ini
+TELA_OWNER_TOKEN=<run: openssl rand -hex 32>
+HUB_DOMAIN=hub.example.com
+```
+
+Optionally also set `TELAHUBD_NAME` (display name shown in TelaVisor and portal listings) and `TELAHUBD_UDP_HOST` (only needed if the UDP relay path reaches the hub through a different hostname than `HUB_DOMAIN`).
+
+Do not commit `.env` anywhere public; it contains the owner token.
+
+#### Step 5. Bring it up
+
+```bash
+docker compose up -d
+```
+
+Caddy takes roughly a minute on first start to issue the Let's Encrypt certificate. `docker compose logs -f caddy` shows the ACME exchange; the final log line is `certificate obtained successfully` on `hub.example.com`.
+
+Once the certificate is issued, verify:
+
+```bash
+curl https://hub.example.com/.well-known/tela
+```
+
+The response is a small JSON document with `hubId` and `protocolVersion` fields. If that is what you see, the hub is live.
+
+#### Step 6. Confirm the owner token
+
+The token is whatever you put in `.env`. To use it from a workstation:
+
+```bash
+tela login https://hub.example.com
+# paste the token when prompted
+```
+
+If you left `TELA_OWNER_TOKEN` blank in `.env`, telahubd auto-generated one on first boot and logged it. Retrieve it either from `docker compose logs telahubd` (the boot banner prints the token once) or on demand:
+
+```bash
+docker exec telahubd telahubd user show-owner -config /data/telahubd.yaml
+```
+
+#### The UDP gotcha
+
+Every compose template in this chapter publishes UDP port 41820 with the `/udp` suffix:
+
+```yaml
+ports:
+  - "41820:41820/udp"
+```
+
+Without the suffix, Docker exposes only the TCP side. telahubd does not listen on TCP 41820, so the mapping silently does nothing, and every relay session falls back to WebSocket-over-TCP. The hub still works but round-trip latency roughly doubles and throughput is cut in half on sessions that would otherwise hole-punch to UDP.
+
+If adapting one of the templates and sessions feel slow, `docker port <container-name>` should report `41820/udp`. If it reports `41820/tcp` instead, the suffix was dropped.
+
+#### Choosing a different template
+
+The Caddy template suits most production deployments. Two alternatives live alongside it:
+
+- [`docker-compose.minimal.yml`](hub-docker/docker-compose.minimal.yml) -- telahubd alone on port 80. For LAN-only dev or test. No TLS.
+- [`docker-compose.nginx.yml`](hub-docker/docker-compose.nginx.yml) -- telahubd plus nginx, for operators who already run nginx. Bring your own certs. The bundled `nginx.conf` includes the WebSocket upgrade handling, which is easy to get wrong.
+
+See [`hub-docker/README.md`](hub-docker/) for the full decision table and per-template notes.
+
+#### Upgrading
+
+Docker-based upgrades use `docker pull` and a compose restart, not `telahubd update`:
+
+```bash
+docker compose pull
+docker compose up -d
+```
+
+The named volume for `/data` survives container recreation, so config and tokens are preserved. To pin to a specific version instead of tracking `:stable`, edit the `image:` line in the compose file to `ghcr.io/paulmooreparks/telahubd:v0.13.0` or any other published tag.
+
+### Install: native binary (alternative)
+
+Pre-built binaries for Windows, Linux, and macOS are available on the [GitHub Releases](https://github.com/paulmooreparks/tela/releases) page. Choose this path if Docker is unavailable on the host, if you are running on Windows Server without Docker Desktop, or if you prefer integrating with the host's service manager directly.
 
 The install flow has five steps. Do them in this order. The service install step writes a clean config file; the bootstrap step adds the owner token to that file; the service-start step reads the populated config. Running them out of order either duplicates tokens or leaves you starting the hub against a blank config.
 
@@ -192,7 +306,9 @@ TELAHUBD_UDP_HOST=myhost.example.com telahubd    # advertise real IP for UDP
 
 ## Authentication
 
-The owner token generated by `telahubd user bootstrap` in step 4 of the install flow is the highest-privilege credential on the hub. An identity with the owner role can add and remove all other identities, change permissions, restart the hub, and perform every administrative operation. Treat it like a root password: store it in a password manager or secrets vault, do not paste it into scripts or shell history, and do not distribute it to agents or end users.
+> **Docker install**: the Docker walkthrough above already set the owner token via `TELA_OWNER_TOKEN` in `.env` and captured it to your password manager. Skip to [Managing tokens remotely with `tela admin`](#managing-tokens-remotely-with-tela-admin) below.
+
+The owner token generated by `telahubd user bootstrap` in step 4 of the native install flow is the highest-privilege credential on the hub. An identity with the owner role can add and remove all other identities, change permissions, restart the hub, and perform every administrative operation. Treat it like a root password: store it in a password manager or secrets vault, do not paste it into scripts or shell history, and do not distribute it to agents or end users.
 
 In normal operation, the owner token is used only from a trusted administrator workstation to run `tela admin` commands. Day-to-day agent connections and user connections use tokens you create with `tela admin tokens add`, which carry the `user` role and are scoped to specific machines via the access control list.
 
@@ -345,6 +461,8 @@ Then add the `tela-hub` network tag to your VM instance.
 **Self-hosted / bare metal:** Ensure `ufw`, `iptables`, or your router forwards these ports to the hub machine.
 
 ## Publish with TLS (recommended)
+
+> **Docker install**: the Docker walkthrough above already configured Caddy and Let's Encrypt via `docker-compose.caddy.yml`. Skip to [Register with a hub directory](#register-with-a-hub-directory) below. The subsections here apply to native installs that need a separately-managed reverse proxy.
 
 Running the hub without TLS (`ws://`) works for local development, but production hubs should use TLS (`wss://`). This protects hub authentication tokens in transit and is required by browsers for the hub console over HTTPS.
 

--- a/internal/hub/auth.go
+++ b/internal/hub/auth.go
@@ -317,9 +317,15 @@ func bootstrapAuth(cfg *hubConfig, cfgPath string, ownerToken string) {
 		ConnectTokens: []string{ownerToken},
 	}
 
-	// Persist so the token survives container restarts.
+	// Persist so the token survives container and service restarts. A
+	// write failure here means bootstrap ran in memory only -- the next
+	// restart will generate a fresh token and the one the operator just
+	// captured is useless. Log loudly; do not silently swallow.
 	if cfgPath != "" {
-		_ = writeHubConfig(cfgPath, cfg)
+		if err := writeHubConfig(cfgPath, cfg); err != nil {
+			log.Printf("[hub] WARNING: bootstrap token not persisted to %s: %v", cfgPath, err)
+			log.Printf("[hub] WARNING: the token above will NOT survive restart; fix config file permissions or restart with a writable -config path")
+		}
 	}
 }
 
@@ -343,9 +349,15 @@ func autoBootstrapAuth(cfg *hubConfig, cfgPath string) bool {
 	fmt.Println("")
 	fmt.Printf("  Owner token: %s\n", ownerToken)
 	fmt.Println("")
-	fmt.Println("  Save this token -- it will not be displayed again.")
 	fmt.Println("  Use it with: tela admin --hub <URL> --token <TOKEN>")
 	fmt.Println("  Or set env:  TELA_OWNER_TOKEN=" + ownerToken)
+	if cfgPath != "" {
+		fmt.Printf("  Persisted to: %s\n", cfgPath)
+		fmt.Println("  Recover later with: telahubd user show-owner -config " + cfgPath)
+	} else {
+		fmt.Println("  WARNING: no -config path set; token is IN-MEMORY ONLY and")
+		fmt.Println("  will be regenerated on restart.")
+	}
 	fmt.Println("==============================================================")
 
 	return true

--- a/internal/hub/health.go
+++ b/internal/hub/health.go
@@ -1,0 +1,122 @@
+// health.go -- "telahubd health" subcommand.
+//
+// A lightweight health probe meant to be invoked from inside the running
+// container by Docker's HEALTHCHECK directive. The distroless runtime
+// image carries no curl or wget, so the binary itself supplies the probe.
+//
+// Exits 0 when the local hub responds to GET /.well-known/tela with a
+// well-formed JSON document carrying the expected "protocolVersion"
+// field. Exits non-zero in every other case (connection refused,
+// timeout, non-2xx, malformed JSON, missing field).
+//
+// Intentionally does NOT exercise any authenticated path. A healthy hub
+// that happens to be in auth-enabled mode still returns 200 on the
+// well-known endpoint; requiring auth for the health probe would force
+// operators to bake a token into the HEALTHCHECK, which is worse.
+
+package hub
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// cmdHealth is the 'telahubd health' entry point.
+func cmdHealth(args []string) {
+	fs := flag.NewFlagSet("telahubd health", flag.ExitOnError)
+	portFlag := fs.Int("port", 0, "Port the hub is listening on (default: TELAHUBD_PORT env var, else 80)")
+	timeoutFlag := fs.Duration("timeout", 3*time.Second, "Overall probe timeout")
+	urlFlag := fs.String("url", "", "Full URL override (default: http://127.0.0.1:<port>/.well-known/tela)")
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, "Usage: telahubd health [-port <n>] [-timeout <duration>] [-url <full-url>]")
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintln(os.Stderr, "Probes the local hub's /.well-known/tela endpoint and exits 0 when")
+		fmt.Fprintln(os.Stderr, "the hub is healthy. Used by the Dockerfile's HEALTHCHECK directive.")
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		os.Exit(2)
+	}
+
+	url := *urlFlag
+	if url == "" {
+		port := *portFlag
+		if port == 0 {
+			if s := strings.TrimSpace(os.Getenv("TELAHUBD_PORT")); s != "" {
+				if n, err := strconv.Atoi(s); err == nil && n > 0 {
+					port = n
+				}
+			}
+		}
+		if port == 0 {
+			port = 80
+		}
+		url = fmt.Sprintf("http://127.0.0.1:%d/.well-known/tela", port)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), *timeoutFlag)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "health: build request: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Fresh transport each call so we never reuse a stale connection and
+	// so the loopback probe is not affected by any proxy env the
+	// container inherits.
+	client := &http.Client{
+		Timeout: *timeoutFlag,
+		Transport: &http.Transport{
+			Proxy: nil,
+			DialContext: (&net.Dialer{
+				Timeout: *timeoutFlag,
+			}).DialContext,
+			DisableKeepAlives: true,
+		},
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "health: %v\n", err)
+		os.Exit(1)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		fmt.Fprintf(os.Stderr, "health: %s returned HTTP %d\n", url, resp.StatusCode)
+		os.Exit(1)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "health: read body: %v\n", err)
+		os.Exit(1)
+	}
+
+	// /.well-known/tela is documented to carry a protocolVersion field.
+	// Check for its presence as a cheap sanity test; a proxy returning a
+	// plain 200 with HTML would otherwise look healthy.
+	var parsed struct {
+		ProtocolVersion string `json:"protocolVersion"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		fmt.Fprintf(os.Stderr, "health: %s returned non-JSON body: %v\n", url, err)
+		os.Exit(1)
+	}
+	if strings.TrimSpace(parsed.ProtocolVersion) == "" {
+		fmt.Fprintf(os.Stderr, "health: %s response missing protocolVersion field\n", url)
+		os.Exit(1)
+	}
+
+	fmt.Printf("ok: telahubd %s listening at %s (protocol %s)\n", version, url, parsed.ProtocolVersion)
+}

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -1957,6 +1957,7 @@ Commands:
   channel   Show or set the hub's release channel (dev, beta, stable, custom)
   channels  Manage a self-hosted release channel server (publish manifests)
   update    Self-update the telahubd binary from the configured release channel
+  health    Probe the local hub and exit 0 if healthy (Docker HEALTHCHECK)
   version   Print version and exit
   help      Show this help (also -h, -?, -help, --help)
 
@@ -2012,6 +2013,9 @@ func Main() {
 			return
 		case "update":
 			cmdSelfUpdate(os.Args[2:])
+			return
+		case "health":
+			cmdHealth(os.Args[2:])
 			return
 		case "version", "--version":
 			fmt.Printf("telahubd %s %s/%s\n", version, runtime.GOOS, runtime.GOARCH)

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -2045,10 +2045,20 @@ func Main() {
 		var err error
 		cfg, err = loadHubConfig(absPath)
 		if err != nil {
-			log.Fatalf("config: %v", err)
+			if errors.Is(err, os.ErrNotExist) {
+				// First-start bootstrap path: the operator pointed -config
+				// at a file that does not exist yet (e.g. a Docker run
+				// against an empty volume). Carry the path forward; the
+				// env-var or auto bootstrap below will create it.
+				log.Printf("[hub] -config %s does not exist; will create on bootstrap", absPath)
+				cfg = nil
+			} else {
+				log.Fatalf("config: %v", err)
+			}
+		} else {
+			log.Printf("[hub] loaded config from %s", absPath)
 		}
 		*configPath = absPath
-		log.Printf("[hub] loaded config from %s", absPath)
 	} else {
 		// Check for previously persisted config (from env bootstrap / admin API)
 		const defaultDataConfig = "data/telahubd.yaml"


### PR DESCRIPTION
## Summary

Closes #58. Ships the Docker distribution path for `telahubd` end to end: a source-built distroless image, multi-arch ghcr.io publishing wired into `release.yml`, a `telahubd health` subcommand for the image's `HEALTHCHECK`, three working `docker-compose` templates (minimal / Caddy / nginx), and a restructured hub install chapter that leads with Docker and demotes the native-binary matrix to an "alternative" section.

Seven commits, built up phase by phase against [`DESIGN-docker.md`](DESIGN-docker.md) which landed as part of this PR to establish the contract before the implementation work.

## What landed

### Phase 1: the image
- `Dockerfile.telahubd` at the repo root. Multi-stage: `golang:1.25-alpine` build, `gcr.io/distroless/static-debian12:nonroot` runtime. 18 MB final size, static binary, non-root user, `/data` volume, ports 80 and 41820/udp exposed.
- `.dockerignore` keeps the build context to just what `go build ./cmd/telahubd` needs.
- Bootstrap fix in `Main()`: `-config <file>` where `<file>` does not exist is now a first-start signal, not a fatal. Without this, `docker run` against an empty volume exited immediately.

### Phase 2: publishing + healthcheck
- New `docker-publish` job in `.github/workflows/release.yml`. Runs after the native-binary release job succeeds. Uses `docker/setup-qemu-action` + `docker/setup-buildx-action` + `docker/build-push-action` for multi-arch (linux/amd64 + linux/arm64). Authenticates with the workflow's `GITHUB_TOKEN` (new `packages: write` permission).
- Tag set per `DESIGN-docker.md` section 3: always `:vX.Y.Z`, plus `:beta` for beta tags, plus `:stable` and `:latest` for stable tags. Dev tags skip Docker publish entirely to keep ghcr.io tidy (design decision 12.1).
- Registry-backed build cache via a `:buildcache` tag.
- `telahubd health` subcommand: GET on `http://127.0.0.1:<port>/.well-known/tela`, validates the response is JSON with a non-empty `protocolVersion`, exits 0 on success. Wired into the Dockerfile's `HEALTHCHECK` directive. The distroless base has no `curl`; having the binary probe itself keeps the image self-contained.

### Phase 3: first-run bootstrap diagnostics
- `bootstrapAuth` persist failures are no longer silently swallowed. A `chown`-less bind mount that blocks the write now logs two `WARNING` lines calling out that the captured token is in-memory only and will not survive restart.
- Auto-bootstrap banner tells the operator where the token was persisted and the `telahubd user show-owner -config <path>` command to retrieve it later. Previously the banner said "it will not be displayed again" with no follow-up breadcrumb.

### Phase 4: compose templates
Three templates under `book/src/howto/hub-docker/`:
- `docker-compose.minimal.yml` -- LAN / dev, no TLS.
- `docker-compose.caddy.yml` + `Caddyfile` -- production, auto-Let's Encrypt. Caddyfile includes the transport-block timeouts long-lived agent WebSockets need.
- `docker-compose.nginx.yml` + `nginx.conf` -- for operators with existing nginx. nginx.conf includes the `$connection_upgrade` map and the 1-hour proxy timeouts that easily get missed.
- Shared `.env.example` + `README.md` that documents the decision and the UDP gotcha prominently.

A fourth template (telahubd + Caddy + Awan Saya as a one-box deployment) was originally planned and is deferred until Awan Saya publishes an image to a container registry.

### Phase 5: book rewrite
- `book/src/howto/hub.md` now leads with "Install: Docker (recommended)" walking the operator through the Caddy template end to end.
- The existing native-install walkthrough is preserved verbatim, retitled "Install: native binary (alternative)", moved below the Docker path.
- Authentication and Publish-with-TLS sections gain short callouts telling Docker-path readers which subsections they have already covered.

## Open questions from the design doc

Section 12 of `DESIGN-docker.md` lists five open questions. Three were decided during implementation:
- **12.1 (dev Docker publishing)**: chose option (a) -- skip entirely. Reflected in the workflow.
- **12.2 (healthcheck shape)**: added `telahubd health` subcommand. Dockerfile uses it.
- **12.3 (signal handling)**: confirmed during Phase 1 smoke tests; Go runtime handles signals fine as PID 1 under distroless.

Two remain open and are best addressed after the first real release-workflow run with this branch merged:
- **12.4 (TelaVisor vs Dockerised hub)**: expected to work unchanged; validate end to end once a `:stable` image exists on ghcr.io.
- **12.5 (logging)**: no action needed; documented to prevent a well-meaning future refactor from changing it.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l .`, `go test ./...` clean on every commit
- [x] `docker build -f Dockerfile.telahubd -t telahubd:dev-test .` produces an 18 MB image
- [x] Locally: `docker run -d -e TELA_OWNER_TOKEN=<hex> telahubd:dev-test` boots, listens on :80 + :41820/udp, serves `/.well-known/tela`, `/api/status` requires auth, HEALTHCHECK reports `Status: healthy`
- [x] Locally: `docker run --rm ... user bootstrap` writes to a named volume and `user show-owner` retrieves the token afterwards
- [x] Locally: auto-bootstrap path (no env var, fresh volume) generates a token, persists it, prints the recovery command
- [x] Locally: `docker compose -f docker-compose.minimal.yml up -d` with the dev-test image tag swapped in produces a working hub with `/41820:41820/udp` correctly mapped
- [ ] In CI: the new `docker-publish` job actually pushes to ghcr.io. Requires this branch merged and a beta or stable promotion triggered.
- [ ] End-to-end: fresh VM with DNS + Docker, `docker compose -f docker-compose.caddy.yml up -d`, TelaVisor connects through the Caddy-fronted hub, an agent registers successfully.

## Follow-ups filed (or worth filing)

- Full-stack compose template (telahubd + Caddy + Awan Saya) once AS ships a registry image.
- Optional: `telahubd update` inside a container could detect the context and print "you are inside a container; use docker pull" instead of trying to overwrite a read-only binary. Low-priority polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)