### PR TITLE
ci: Decouple Site Deploys From the Book Pipeline

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -1,0 +1,82 @@
+# Deploy the telaproject.org landing page (site/*) on every main push
+# that touches it. Decoupled from the book release pipeline so typo fixes
+# and style tweaks don't need a version bump to go live.
+#
+# Layout preserved on gh-pages (via peaceiris keep_files: true):
+#   /                   <- landing page from site/*
+#   /tdl.css            <- TDL stylesheet (from site/tdl.css)
+#   /style.css, /404.html, /assets/*
+#   /book/...           <- owned by docs.yml (tag-triggered), untouched here
+#   /versions.json      <- owned by docs.yml, read here but not written
+#   /CNAME              <- owned by Pages, preserved
+#
+# The site's hero CTA and stable version card reference the stable
+# version via a __TELA_SITE_STABLE_VERSION__ placeholder. This workflow
+# substitutes it with whatever stable version is currently published
+# in gh-pages:/versions.json. On a new stable cut, docs.yml rewrites
+# versions.json AND redeploys the landing page with the new tag baked
+# in, so the site stays fresh even between site/* edits.
+#
+# See DESIGN-telaproject-site.md section 8 and the sibling docs.yml.
+
+name: Site
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "site/**"
+      - ".github/workflows/site.yml"
+  workflow_dispatch: {}
+
+permissions:
+  contents: write  # peaceiris/actions-gh-pages pushes to the gh-pages branch
+
+concurrency:
+  group: site
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+
+      - name: Look up current stable version from gh-pages versions.json
+        id: stable
+        run: |
+          set -e
+          # Fetch gh-pages without cloning its full history.
+          git fetch origin gh-pages --depth=1 || true
+          if git show origin/gh-pages:versions.json >/dev/null 2>&1; then
+            STABLE=$(git show origin/gh-pages:versions.json \
+              | jq -r '.current.stable.version // ""')
+          else
+            STABLE=""
+          fi
+          if [ -z "$STABLE" ]; then
+            echo "::warning::No current stable version in versions.json; placeholder will remain literal"
+            STABLE="__TELA_SITE_STABLE_VERSION__"
+          fi
+          echo "version=$STABLE" >> "$GITHUB_OUTPUT"
+          echo "Using stable version: $STABLE"
+
+      - name: Stage site assets
+        env:
+          STABLE: ${{ steps.stable.outputs.version }}
+        run: |
+          mkdir -p _site
+          cp -r site/. _site/
+          if [ -f _site/index.html ]; then
+            sed -i "s|__TELA_SITE_STABLE_VERSION__|$STABLE|g" _site/index.html
+          fi
+          ls -la _site/
+
+      - name: Deploy to gh-pages root
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./_site
+          keep_files: true
+          commit_message: "site: deploy landing page from ${{ github.sha }}"


### PR DESCRIPTION
## Summary

Add a new workflow, `site.yml`, that deploys the landing page (`site/**`) on every main push that touches it. The existing book pipeline in `docs.yml` keeps its tag-triggered model; both workflows write to `gh-pages` with `keep_files: true` so they don't step on each other.

## Motivation

Before this PR: the landing page only shipped on stable tag cuts. Content edits or style fixes between releases had to be hand-slipstreamed onto `gh-pages` (we did this four times in the last few hours for various typo/style/content fixes). Version bumps for a CSS tweak are heavier than warranted.

After this PR: push to main touches `site/**`, workflow runs, landing page is live within ~1 minute.

## What changed

New file: `.github/workflows/site.yml`.

- Triggers: `push` to `main` touching `site/**` or the workflow itself; `workflow_dispatch` for manual re-runs.
- Reads the current stable version from `gh-pages:/versions.json` (which `docs.yml` writes on every tag push) and seds it into `__TELA_SITE_STABLE_VERSION__` on `site/index.html`. Falls safely back to leaving the literal placeholder if `versions.json` is missing or empty, with a workflow warning.
- Deploys via `peaceiris/actions-gh-pages@v4` with `keep_files: true` so `/book/**`, `/versions.json`, `CNAME`, and other gh-pages contents survive.
- Concurrency group `site` with `cancel-in-progress: false` so rapid pushes serialize cleanly.

## Ownership boundaries on gh-pages

| Path | Owner workflow |
|---|---|
| `/`, `/tdl.css`, `/style.css`, `/404.html`, `/assets/*` | `site.yml` (new) |
| `/book/**`, `/book/archive/**` | `docs.yml` (unchanged) |
| `/versions.json` | `docs.yml` (written on every tag deploy) |
| `/CNAME` | GitHub Pages (preserved) |

## Interaction with stable release cuts

`docs.yml` still deploys the landing page on stable cuts with the new tag baked in, as before. `site.yml` also deploys when site source changes. Both workflows are idempotent and converge on the same state; the redundancy is intentional belt-and-suspenders.

## Test plan

- [ ] Merge this PR. Verify `site.yml` doesn't fire on the merge commit itself (merge didn't touch `site/**`).
- [ ] Push a trivial site edit to main (typo fix or comment). Verify `site.yml` triggers, succeeds, and the change is live on `telaproject.org/` within ~1 minute.
- [ ] Confirm `/book/**` and `/versions.json` are untouched on gh-pages after the site-only deploy.
- [ ] Next time a new stable is cut, confirm the landing page's stable-version placeholder is updated correctly (exercises the docs.yml path too).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>