### PR TITLE
test: goroutine-leak detection in the teststack harness; #6 closeout

### DIFF
--- a/ROADMAP-1.0.md
+++ b/ROADMAP-1.0.md
@@ -39,7 +39,7 @@ These are non-negotiable. A 1.0 without them would be embarrassing or actively u
 The harness exists and several packages carry real coverage, but the security-critical paths (auth store, admin API, wsbind transport, WG reconnect) still need their suites before 1.0 locks the access model and wire protocol.
 
 Already done:
-- [x] `internal/teststack`: the in-process hub + agent + client harness (`New(t)` returns a running triple with cleanup), with smoke tests for registration, client connect with listener bind, multi-machine, protocol version reporting, bridged sessions, and reset-between-runs. Two #6 acceptance boxes remain open (goroutine-leak detection in CI, adoption by two other suites), so #6 stays open until the auth-store and admin API suites consume it.
+- [x] `internal/teststack`: the in-process hub + agent + client harness (`New(t)` returns a running triple with cleanup), with smoke tests for registration, client connect with listener bind, multi-machine, protocol version reporting, bridged sessions, and reset-between-runs. Both #6 acceptance boxes are now closed: `Stack.Close()` runs a goroutine-leak check (baseline captured in `NewWithConfig`, enforced in CI), and two other suites consume the harness over real HTTP (`internal/hub/admin_api_e2e_test.go` and `internal/portal/teststack_test.go`).
 - [x] `permuteArgs` flag reordering tests (`cmd/tela/admin_test.go`, 16 sub-tests)
 - [x] `internal/channel` tests: manifest parsing/validation, URL helpers, Fetcher cache + stale-on-failure, VerifyReader (94.4% coverage)
 - [x] `internal/credstore` tests: round-trip, normalization, permission bits, edge cases (62.7% coverage)
@@ -48,7 +48,6 @@ Already done:
 - [x] `internal/portal`, `store/file`, `portalclient`, and `portalaggregate` tests, including the portal conformance harness
 
 Open issues:
-- [#6](https://github.com/paulmooreparks/tela/issues/6): harness residuals only (goroutine-leak detection in CI, adoption by two suites); the harness core shipped
 - [#7](https://github.com/paulmooreparks/tela/issues/7) — Auth store unit tests
 - [#8](https://github.com/paulmooreparks/tela/issues/8) — Admin API endpoint tests
 - [#9](https://github.com/paulmooreparks/tela/issues/9) — Ring buffer history tests

--- a/internal/teststack/stack.go
+++ b/internal/teststack/stack.go
@@ -37,6 +37,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -64,6 +65,25 @@ func init() {
 	telelog.Init("test", out)
 }
 
+// Leak-check tuning. checkGoroutineLeak polls the live goroutine count
+// against the per-Stack baseline for up to leakCheckGrace, sampling every
+// leakCheckPoll, and allows leakCheckTolerance goroutines of headroom.
+//
+// The tolerance is 2 because hub.Run starts exactly two background
+// goroutines that outlive the hub's context: runKeepalive and
+// runUDPSessionReaper both loop on a time.Ticker with no quit channel, so
+// context cancellation does not stop them (they are process-lifetime hub
+// goroutines, one pair per hub, absorbed into the next Stack's baseline).
+// The baseline is captured before hub.Run, so those two never appear in it
+// and the tolerance is what keeps a clean hub-only teardown green. Any leak
+// beyond that pair (client-tunnel session loops, gvisor netstack workers,
+// relay dial loops) is what this check is here to catch.
+const (
+	leakCheckGrace     = 2 * time.Second
+	leakCheckPoll      = 50 * time.Millisecond
+	leakCheckTolerance = 2
+)
+
 // Stack is one in-process hub + one in-process agent. Tests construct
 // it via New(t), exercise it through the helper methods, and let
 // t.Cleanup tear it down.
@@ -71,6 +91,17 @@ type Stack struct {
 	t      *testing.T
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
+
+	// goroutineBaseline is runtime.NumGoroutine() captured at the top of
+	// NewWithConfig, before any harness goroutine is launched. Close()
+	// compares the live count against this to catch goroutines spawned
+	// inside hub.Run/agent.Run/client.Connect that the wg does not track.
+	goroutineBaseline int
+
+	// skipLeakCheck suppresses Close()'s goroutine-leak assertion. Set only
+	// via SkipLeakCheck for the one in-process configuration where a leak is
+	// a documented harness limitation, not a defect. See SkipLeakCheck.
+	skipLeakCheck bool
 
 	tempDir   string
 	hubAddr   string
@@ -112,6 +143,7 @@ func New(t *testing.T) *Stack {
 // random ports so concurrent tests do not collide.
 func NewWithConfig(t *testing.T, cfg *hub.Config) *Stack {
 	t.Helper()
+	baseline := runtime.NumGoroutine()
 
 	tempDir, err := os.MkdirTemp("", "tela-stack-*")
 	if err != nil {
@@ -119,9 +151,10 @@ func NewWithConfig(t *testing.T, cfg *hub.Config) *Stack {
 	}
 
 	s := &Stack{
-		t:         t,
-		tempDir:   tempDir,
-		agentYAML: filepath.Join(tempDir, "telad.yaml"),
+		t:                 t,
+		goroutineBaseline: baseline,
+		tempDir:           tempDir,
+		agentYAML:         filepath.Join(tempDir, "telad.yaml"),
 	}
 	s.startHubWithConfig(cfg)
 	t.Cleanup(s.Close)
@@ -417,4 +450,53 @@ func (s *Stack) Close() {
 	// Remove the temp directory. Best-effort; ignore errors so test
 	// teardown does not mask the real test failure.
 	_ = os.RemoveAll(s.tempDir)
+
+	// Enforce that every goroutine the harness spawned has unwound. This
+	// is the GitHub #6 leak-detection gate: unlike the wg-wait above, it
+	// also catches goroutines started inside hub.Run/agent.Run/client.Connect
+	// (gvisor netstack workers, WireGuard session loops, relay dial loops)
+	// that the wg never tracked. Suppressed only for the documented
+	// in-process client-tunnel limitation (see SkipLeakCheck).
+	if !s.skipLeakCheck {
+		checkGoroutineLeak(s.t, s.goroutineBaseline)
+	}
+}
+
+// SkipLeakCheck disables Close()'s goroutine-leak assertion for this Stack.
+// It is reserved for the single in-process configuration where a residual
+// goroutine is a known, documented harness limitation rather than a defect
+// in the code under test: the client-tunnel path (Connect) drives gvisor's
+// netstack and the client/agent WireGuard session loops, and in a single OS
+// process the inner gvisor TCP handshake never completes (the same
+// limitation TestStackClientConnectsAndBindsListener documents). That path
+// leaves a gvisor worker plus a hub-side handleConnect retry goroutine
+// (a 30s time.Sleep) that outlive Close()'s context cancellation and the
+// leak-check grace window. The production, separate-process path does not
+// hit this. Do not call SkipLeakCheck to paper over a real leak in new
+// harness consumers; the whole point of the check is to catch those.
+func (s *Stack) SkipLeakCheck() {
+	s.skipLeakCheck = true
+}
+
+// checkGoroutineLeak polls the live goroutine count against baseline plus
+// leakCheckTolerance for up to leakCheckGrace. It returns as soon as the
+// count settles within tolerance. If the grace window elapses first it
+// fails the test (t.Errorf, not t.Logf: this is the enforcement point) and
+// dumps every live goroutine's stack for diagnosis.
+func checkGoroutineLeak(t *testing.T, baseline int) {
+	t.Helper()
+	limit := baseline + leakCheckTolerance
+	deadline := time.Now().Add(leakCheckGrace)
+	for {
+		if n := runtime.NumGoroutine(); n <= limit {
+			return
+		} else if time.Now().After(deadline) {
+			buf := make([]byte, 1<<20)
+			written := runtime.Stack(buf, true)
+			t.Errorf("teststack: goroutine leak: %d goroutines after Close, want <= %d (baseline %d)\n%s",
+				n, limit, baseline, buf[:written])
+			return
+		}
+		time.Sleep(leakCheckPoll)
+	}
 }

--- a/internal/teststack/stack_test.go
+++ b/internal/teststack/stack_test.go
@@ -141,6 +141,13 @@ func TestRegisterReportsProtocolVersion(t *testing.T) {
 // of running a true echo through gvisor.
 func TestStackClientConnectsAndBindsListener(t *testing.T) {
 	stack := New(t)
+	// The same in-process gvisor limitation described above also leaves a
+	// gvisor netstack worker and a hub-side handleConnect retry goroutine
+	// (a 30s time.Sleep) alive past Close()'s context cancellation and the
+	// leak-check grace window. That is a documented harness limitation of
+	// the client-tunnel path in a single OS process, not a leak in the code
+	// under test, so this is the one test that opts out of the leak check.
+	stack.SkipLeakCheck()
 	echoPort := stack.StartLocalEcho()
 	stack.AddMachine("barn", []uint16{echoPort})
 	stack.WaitAgentRegistered("barn", 5*time.Second)


### PR DESCRIPTION
Closes the two residual boxes on GitHub #6. Leak detection: the harness captures a goroutine baseline before startup and Stack.Close() polls the live count against baseline plus a documented tolerance of two (the known hub.Run keepalive and UDP-reaper ticker leaks, tracked separately on the board as tela-68) for a 2s grace window, failing the test with a full stack dump on breach; the one test that legitimately trips it (the documented gVisor inner-dial hang) opts out via an explicit SkipLeakCheck with rationale. Adoption: verified two genuine real-HTTP consumers of the harness, internal/hub/admin_api_e2e_test.go and internal/portal/teststack_test.go. ROADMAP-1.0.md test section updated to match.

Card: tela-65
Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)