### PR TITLE
test: WireGuard handshake-on-reconnect end-to-end coverage

### DIFF
--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -4257,3 +4257,56 @@ func SetTestConfig(cfg *Config) {
 func SetUDPPortForTesting(p int) {
 	udpPort.Store(int32(p))
 }
+
+// DisconnectClientSessionForTesting closes the hub-side WebSocket for the
+// active client session on machineID (the operator-assigned machine name,
+// e.g. "barn"), simulating a session severed by the hub: a dropped
+// connection, an operator kick, a mid-session hub restart, without
+// touching the agent's control channel or the client process. It sends a
+// graceful close frame (CloseGoingAway) before closing the socket,
+// mirroring the pattern already used in handleDisconnect's "agent" case.
+//
+// Closing sess.ClientWS makes the hub's own per-connection reader loop for
+// that socket error out and run handleDisconnect's "client" branch, which
+// removes the session from entry.Sessions (dropping sessionCount) and
+// notifies the agent side with session-end. gorilla/websocket documents
+// Close and WriteControl as safe to call concurrently with a blocked
+// ReadMessage, so calling this from a test goroutine while the reader loop
+// is parked in ReadMessage is race-safe by contract.
+//
+// Returns false if machineID is not registered or has no active session.
+// If more than one session is active, an arbitrary one is closed; the
+// teststack callers this exists for only ever drive one session per
+// machine.
+//
+// Test-only: exported for internal/teststack. Never called by production code.
+func DisconnectClientSessionForTesting(machineID string) bool {
+	machinesMu.RLock()
+	agentID := machinesByName[machineID]
+	machinesMu.RUnlock()
+	if agentID == "" {
+		return false
+	}
+	machinesMu.RLock()
+	entry := machines[agentID]
+	machinesMu.RUnlock()
+	if entry == nil {
+		return false
+	}
+
+	entry.mu.Lock()
+	var sess *clientSession
+	for _, s := range entry.Sessions {
+		sess = s
+		break
+	}
+	entry.mu.Unlock()
+	if sess == nil || sess.ClientWS == nil {
+		return false
+	}
+
+	sess.ClientWS.WriteMessage(websocket.CloseMessage,
+		websocket.FormatCloseMessage(websocket.CloseGoingAway, "test-forced disconnect"))
+	sess.ClientWS.Close()
+	return true
+}

--- a/internal/teststack/reconnect_test.go
+++ b/internal/teststack/reconnect_test.go
@@ -1,0 +1,84 @@
+package teststack
+
+import (
+	"testing"
+	"time"
+
+	"github.com/paulmooreparks/tela/internal/hub"
+)
+
+// TestStackHandshakeOnReconnect verifies that severing a client's session
+// from the hub causes the client to redial and complete a NEW hub-side
+// session pairing (a new WireGuard handshake) within its normal reconnect
+// backoff window. Tracks GitHub #11.
+//
+// The disruption is server-side and surgical: the hub closes the client
+// session's WebSocket via DisconnectClientSessionForTesting, which
+// simulates a dropped connection, an operator kick, or a mid-session hub
+// restart without killing the agent process, the client process, or the
+// client's own connection. Reconnection is proven at the
+// session-establishment layer through existing hub telemetry: sessionCount
+// transitions 1 -> 0 -> 1, and the machine's "client-connect" history
+// event count reaches 2 (each successful pairSession records exactly one
+// such event, so a second event is a distinct new pairing, not a stale
+// reused one). Both sides mint fresh per-session X25519 keypairs and bring
+// up a new WireGuard device on every pairing, so this pair of signals is a
+// reliable proxy for a genuinely new handshake.
+//
+// What this test does NOT cover, and does not imply coverage of:
+//   - Real byte-echo through the reconnected tunnel. The same in-process
+//     gvisor limitation that TestStackClientConnectsAndBindsListener
+//     documents applies; no forwarded TCP flow is opened here (see
+//     ConnectTunnelOnly), so actual data-plane resumption is not asserted.
+//   - Direct-P2P reconnect (STUN/hole-punch, tryDirectUpgrade). The harness
+//     cannot drive real NAT traversal in one process.
+//   - UDP-relay reconnect (tryUDPUpgrade). The reconnect proven here is over
+//     the WebSocket-relayed WireGuard path that every session starts on.
+//   - Bridge-federated reconnect (Hub-A/Hub-B). This card is single-hub.
+//
+// No time.Sleep-based synchronization appears below: every wait is a
+// bounded poll against a real hub-observed signal.
+func TestStackHandshakeOnReconnect(t *testing.T) {
+	stack := New(t)
+	// Empirically (verified by running this test), the no-forwarding path
+	// still trips the goroutine-leak check, so this test opts out. The
+	// leak is NOT the gvisor netstack worker that the forwarding path
+	// leaks (no forwarded flow is opened here); it is the hub-side
+	// agent-join timeout guard. Every client connect spawns a goroutine in
+	// handleConnect (hub.go:1499) that does an uncancellable 30s time.Sleep
+	// before checking whether the agent joined the session. It exits about
+	// 30s after connect, far outside Close()'s 2s leak-check grace window.
+	// This test establishes two sessions (initial + reconnect), so two such
+	// guards are still sleeping at teardown, two goroutines past the
+	// tolerance. This is the same "hub-side handleConnect retry goroutine
+	// (a 30s time.Sleep)" class the SkipLeakCheck doc already names, reached
+	// here through the ordinary connect path rather than the forwarding
+	// hang. See SkipLeakCheck in stack.go.
+	stack.SkipLeakCheck()
+	stack.AddMachine("barn", []uint16{22})
+	stack.WaitAgentRegistered("barn", 5*time.Second)
+
+	stack.ConnectTunnelOnly("barn")
+
+	// First session pairs. Near-instant in-process; no backoff on the
+	// first connect.
+	stack.WaitSessionCount("barn", 1, 5*time.Second)
+	stack.WaitHistoryEventCount("barn", "client-connect", 1, 5*time.Second)
+
+	// Sever the session from the hub side.
+	if !hub.DisconnectClientSessionForTesting("barn") {
+		t.Fatal(`DisconnectClientSessionForTesting: no active session for "barn"`)
+	}
+
+	// Hub-observed teardown: handleDisconnect runs synchronously off the
+	// closed-socket read error, so sessionCount drops to 0 quickly.
+	stack.WaitSessionCount("barn", 0, 5*time.Second)
+
+	// The client redials after reconnectDelay(0, maxDelay): a 3s base with
+	// +/-25% jitter, so 2.25-3.75s typical. A 15s budget leaves roughly 4x
+	// margin for CI scheduling jitter without masking a real regression: a
+	// hung reconnect still fails well inside 15s, a healthy one completes
+	// in well under 5s.
+	stack.WaitSessionCount("barn", 1, 15*time.Second)
+	stack.WaitHistoryEventCount("barn", "client-connect", 2, 15*time.Second)
+}

--- a/internal/teststack/stack.go
+++ b/internal/teststack/stack.go
@@ -367,6 +367,146 @@ func (s *Stack) Connect(machineID string, localPort, remotePort uint16) {
 	}()
 }
 
+// ConnectTunnelOnly opens an in-process tela client session against
+// machineID with no port mappings: no local listener is bound and no
+// tunnel forwarding is attempted, so the client's netstack never issues
+// an inner TCP dial. See the reconnect test's design-decision note for
+// why: a forwarded flow hangs forever in this single-process harness
+// (the same limitation TestStackClientConnectsAndBindsListener
+// documents). ConnectTunnelOnly exercises session establishment (WS
+// connect, WireGuard keygen, hub pairing, wg-pubkey/ready exchange,
+// dev.Up()) and reconnection without touching that broken inner-dial
+// path. The session lives until the stack closes.
+func (s *Stack) ConnectTunnelOnly(machineID string) {
+	s.t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	prevCancel := s.cancel
+	s.cancel = func() {
+		cancel()
+		if prevCancel != nil {
+			prevCancel()
+		}
+	}
+
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		err := client.Connect(ctx, client.ConnectOptions{
+			HubURL:    s.hubURL,
+			MachineID: machineID,
+		})
+		if err != nil && ctx.Err() == nil {
+			s.t.Errorf("teststack: client.Connect (tunnel-only): %v", err)
+		}
+	}()
+}
+
+// WaitSessionCount polls /api/status until machineID's sessionCount
+// equals want, or fails the test after timeout. It is the synchronization
+// point for hub-observed session teardown (want=0) and re-pairing
+// (want=1) around a reconnect. No fixed sleeps; every wait is a bounded
+// poll against the hub's live status.
+func (s *Stack) WaitSessionCount(machineID string, want int, timeout time.Duration) {
+	s.t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	url := s.hubHTTP + "/api/status"
+	var last int = -1
+	for time.Now().Before(deadline) {
+		got, ok := s.sessionCount(url, machineID)
+		if ok {
+			last = got
+			if got == want {
+				return
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	s.t.Fatalf("teststack: sessionCount for %q did not reach %d within %s (last observed %d)",
+		machineID, want, timeout, last)
+}
+
+// sessionCount returns machineID's sessionCount from /api/status and
+// whether the machine was present in the response.
+func (s *Stack) sessionCount(url, machineID string) (int, bool) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return 0, false
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return 0, false
+	}
+	var payload struct {
+		Machines []struct {
+			ID           string `json:"id"`
+			SessionCount int    `json:"sessionCount"`
+		} `json:"machines"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return 0, false
+	}
+	for _, m := range payload.Machines {
+		if m.ID == machineID {
+			return m.SessionCount, true
+		}
+	}
+	return 0, false
+}
+
+// WaitHistoryEventCount polls /api/history until at least want events of
+// type event are recorded for machineID, or fails the test after timeout.
+// Each successful hub-side pairSession call records exactly one
+// "client-connect" event, so this proves a NEW pairing happened, not just
+// that the client believes it reconnected.
+func (s *Stack) WaitHistoryEventCount(machineID, event string, want int, timeout time.Duration) {
+	s.t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	url := s.hubHTTP + "/api/history"
+	last := 0
+	for time.Now().Before(deadline) {
+		got := s.historyEventCount(url, machineID, event)
+		last = got
+		if got >= want {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	s.t.Fatalf("teststack: history events of type %q for %q did not reach %d within %s (last observed %d)",
+		event, machineID, want, timeout, last)
+}
+
+// historyEventCount returns how many events of type event are recorded
+// for machineID in /api/history.
+func (s *Stack) historyEventCount(url, machineID, event string) int {
+	resp, err := http.Get(url)
+	if err != nil {
+		return 0
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return 0
+	}
+	var payload struct {
+		Events []struct {
+			MachineID string `json:"machineId"`
+			Event     string `json:"event"`
+		} `json:"events"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return 0
+	}
+	n := 0
+	for _, e := range payload.Events {
+		if e.MachineID == machineID && e.Event == event {
+			n++
+		}
+	}
+	return n
+}
+
 // StartLocalEcho starts a TCP echo server bound to 127.0.0.1 on a
 // random port and returns the port it picked. Used by tests as the
 // "real" service the agent forwards to. The listener is closed when
@@ -463,17 +603,29 @@ func (s *Stack) Close() {
 }
 
 // SkipLeakCheck disables Close()'s goroutine-leak assertion for this Stack.
-// It is reserved for the single in-process configuration where a residual
+// It is reserved for the in-process configurations where a residual
 // goroutine is a known, documented harness limitation rather than a defect
-// in the code under test: the client-tunnel path (Connect) drives gvisor's
-// netstack and the client/agent WireGuard session loops, and in a single OS
-// process the inner gvisor TCP handshake never completes (the same
-// limitation TestStackClientConnectsAndBindsListener documents). That path
-// leaves a gvisor worker plus a hub-side handleConnect retry goroutine
-// (a 30s time.Sleep) that outlive Close()'s context cancellation and the
-// leak-check grace window. The production, separate-process path does not
-// hit this. Do not call SkipLeakCheck to paper over a real leak in new
-// harness consumers; the whole point of the check is to catch those.
+// in the code under test. Two such configurations are documented today:
+//
+//   - The client-tunnel path (Connect) drives gvisor's netstack and the
+//     client/agent WireGuard session loops, and in a single OS process the
+//     inner gvisor TCP handshake never completes (the same limitation
+//     TestStackClientConnectsAndBindsListener documents). That path leaves a
+//     gvisor worker plus a hub-side handleConnect retry goroutine (a 30s
+//     time.Sleep) that outlive Close()'s context cancellation and the
+//     leak-check grace window.
+//
+//   - The no-forwarding session path (ConnectTunnelOnly, used by
+//     TestStackHandshakeOnReconnect) never opens a forwarded flow, so it
+//     avoids the gvisor worker, but it still spawns the hub-side
+//     handleConnect agent-join timeout guard: an uncancellable 30s
+//     time.Sleep started on every client connect (hub.go:1499). One such
+//     guard per session established is still sleeping at teardown, past the
+//     leak-check grace window.
+//
+// The production, separate-process path does not hit either case. Do not
+// call SkipLeakCheck to paper over a real leak in new harness consumers;
+// the whole point of the check is to catch those.
 func (s *Stack) SkipLeakCheck() {
 	s.skipLeakCheck = true
 }


### PR DESCRIPTION
Proves a full re-handshake after session disruption per GitHub #11: a hub-side test hook closes the client WS through the hub's own read loop (driving the genuine handleDisconnect path), and the test asserts sessionCount 1-0-1 on /api/status plus client-connect count 1-2 on /api/history within bounded polls, no sleeps. Uses a no-forwarding tunnel session to stay clear of the documented in-process gVisor forwarded-flow hang; the leak-check opt-out carries an inline justification naming the hub's uncancellable 30s agent-join guard, now folded into board card tela-68. New teststack helpers: ConnectTunnelOnly, WaitSessionCount, WaitHistoryEventCount.

Card: tela-17
Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)