### PR TITLE
test: wsbind transport matrix across WS, UDP relay, and direct tiers

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -2361,7 +2361,7 @@ persistent_keepalive_interval=25
 	keepaliveRespCh, stopKeepalive := bind.StartSessionKeepalive(func() {
 		lg.Printf("session keepalive timeout -- tearing down")
 		ws.Close()
-	})
+	}, relay.KeepaliveInterval, relay.KeepaliveTimeout)
 	defer stopKeepalive()
 
 	// Start reader goroutine: WebSocket binary → wsBind.RecvCh

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -2003,7 +2003,7 @@ persistent_keepalive_interval=25
 	keepaliveRespCh, stopKeepalive := bind.StartSessionKeepalive(func() {
 		log.Printf("session keepalive timeout -- tearing down")
 		wsConn.Close()
-	})
+	}, relay.KeepaliveInterval, relay.KeepaliveTimeout)
 	defer stopKeepalive()
 
 	// Start reader goroutine: WebSocket binary → wsBind.RecvCh

--- a/internal/wsbind/bind.go
+++ b/internal/wsbind/bind.go
@@ -90,6 +90,8 @@ type Bind struct {
 	// STUN / hole-punch signaling
 	stunCh  chan []byte       // STUN binding responses routed here by udpReader
 	punchCh chan *net.UDPAddr // hole-punch probe signals from udpReader
+
+	stunAddr string // test-only override for the STUN server address; empty means use stunServer
 }
 
 // New creates a Bind using the given WebSocket connection.
@@ -395,7 +397,11 @@ func (b *Bind) STUNDiscover() (string, error) {
 	binary.BigEndian.PutUint32(req[4:8], stunMagicCookie)
 	copy(req[8:20], txID)
 
-	stunAddr, err := net.ResolveUDPAddr("udp4", stunServer)
+	serverAddr := stunServer
+	if b.stunAddr != "" {
+		serverAddr = b.stunAddr
+	}
+	stunAddr, err := net.ResolveUDPAddr("udp4", serverAddr)
 	if err != nil {
 		return "", fmt.Errorf("resolve STUN server: %w", err)
 	}
@@ -626,17 +632,19 @@ func (b *Bind) SendControlFrame(payload []byte) error {
 }
 
 // StartSessionKeepalive starts a goroutine that sends periodic in-band
-// session keepalive requests (CONTROL frame, payload 0x01) and calls
-// closeFn if no response arrives within relay.KeepaliveTimeout.
+// session keepalive requests (CONTROL frame, payload 0x01) every interval
+// and calls closeFn if no response arrives within timeout. Production passes
+// relay.KeepaliveInterval and relay.KeepaliveTimeout; the parameters exist so
+// tests can drive the loop on a short clock.
 //
 // Returns (respCh, stop):
 //   - respCh: the caller sends on this channel when a keepalive response (0x02) is received.
 //   - stop: call to cancel the keepalive goroutine.
-func (b *Bind) StartSessionKeepalive(closeFn func()) (chan<- struct{}, func()) {
+func (b *Bind) StartSessionKeepalive(closeFn func(), interval, timeout time.Duration) (chan<- struct{}, func()) {
 	respCh := make(chan struct{}, 1)
 	stop := make(chan struct{})
 	go func() {
-		ticker := time.NewTicker(relay.KeepaliveInterval)
+		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
 		var lastReqAt time.Time
 		waiting := false
@@ -645,7 +653,7 @@ func (b *Bind) StartSessionKeepalive(closeFn func()) (chan<- struct{}, func()) {
 			case <-stop:
 				return
 			case <-ticker.C:
-				if waiting && time.Since(lastReqAt) >= relay.KeepaliveTimeout {
+				if waiting && time.Since(lastReqAt) >= timeout {
 					closeFn()
 					return
 				}

--- a/internal/wsbind/bind_test.go
+++ b/internal/wsbind/bind_test.go
@@ -1,0 +1,188 @@
+package wsbind
+
+import (
+	"bytes"
+	"encoding/binary"
+	"net"
+	"testing"
+
+	"github.com/paulmooreparks/tela/internal/relay"
+)
+
+// buildSTUNSuccess crafts a STUN Binding Success Response (msgType 0x0101)
+// echoing txID and carrying a single IPv4 XOR-MAPPED-ADDRESS attribute for
+// ip:port. The returned bytes decode cleanly through parseSTUNResponse. It is
+// shared by the Tier A parse tests and the Tier B STUNDiscover responder.
+func buildSTUNSuccess(txID []byte, ip net.IP, port uint16) []byte {
+	ip4 := ip.To4()
+	attr := make([]byte, 12) // 2 type + 2 len + 8 value
+	binary.BigEndian.PutUint16(attr[0:2], 0x0020)
+	binary.BigEndian.PutUint16(attr[2:4], 8)
+	attr[4] = 0x00 // reserved
+	attr[5] = 0x01 // IPv4 family
+	xPort := port ^ uint16(stunMagicCookie>>16)
+	binary.BigEndian.PutUint16(attr[6:8], xPort)
+	xIP := binary.BigEndian.Uint32(ip4) ^ stunMagicCookie
+	binary.BigEndian.PutUint32(attr[8:12], xIP)
+
+	resp := make([]byte, 20+len(attr))
+	binary.BigEndian.PutUint16(resp[0:2], 0x0101) // Binding Success Response
+	binary.BigEndian.PutUint16(resp[2:4], uint16(len(attr)))
+	binary.BigEndian.PutUint32(resp[4:8], stunMagicCookie)
+	copy(resp[8:20], txID)
+	copy(resp[20:], attr)
+	return resp
+}
+
+// --- Tier A: pure unit, no sockets ---
+
+// TestParseSTUNResponse_Valid covers matrix item 1: a well-formed Binding
+// Success Response with a matching transaction ID yields the reflexive
+// IPv4 address.
+func TestParseSTUNResponse_Valid(t *testing.T) {
+	txID := []byte("0123456789ab")
+	resp := buildSTUNSuccess(txID, net.IPv4(1, 2, 3, 4), 1234)
+
+	got, err := parseSTUNResponse(resp, txID)
+	if err != nil {
+		t.Fatalf("parseSTUNResponse: %v", err)
+	}
+	if got != "1.2.3.4:1234" {
+		t.Fatalf("reflexive address = %q, want %q", got, "1.2.3.4:1234")
+	}
+}
+
+// TestParseSTUNResponse_Errors covers matrix item 2: five distinct negative
+// cases each return an error and no address.
+func TestParseSTUNResponse_Errors(t *testing.T) {
+	txID := []byte("0123456789ab")
+	base := buildSTUNSuccess(txID, net.IPv4(1, 2, 3, 4), 1234)
+
+	t.Run("wrong msgType", func(t *testing.T) {
+		bad := append([]byte(nil), base...)
+		binary.BigEndian.PutUint16(bad[0:2], 0x0001) // Binding Request, not Success Response
+		if _, err := parseSTUNResponse(bad, txID); err == nil {
+			t.Fatal("expected error on wrong msgType")
+		}
+	})
+
+	t.Run("wrong magic cookie", func(t *testing.T) {
+		bad := append([]byte(nil), base...)
+		binary.BigEndian.PutUint32(bad[4:8], 0xDEADBEEF)
+		if _, err := parseSTUNResponse(bad, txID); err == nil {
+			t.Fatal("expected error on magic cookie mismatch")
+		}
+	})
+
+	t.Run("wrong transaction ID", func(t *testing.T) {
+		if _, err := parseSTUNResponse(base, []byte("ffffffffffff")); err == nil {
+			t.Fatal("expected error on transaction ID mismatch")
+		}
+	})
+
+	t.Run("too short", func(t *testing.T) {
+		if _, err := parseSTUNResponse(base[:19], txID); err == nil {
+			t.Fatal("expected error on sub-20-byte response")
+		}
+	})
+
+	t.Run("missing XOR-MAPPED-ADDRESS", func(t *testing.T) {
+		// A 20-byte header with no attributes: valid type/cookie/txID but no
+		// address attribute present.
+		noAttr := make([]byte, 20)
+		binary.BigEndian.PutUint16(noAttr[0:2], 0x0101)
+		binary.BigEndian.PutUint16(noAttr[2:4], 0)
+		binary.BigEndian.PutUint32(noAttr[4:8], stunMagicCookie)
+		copy(noAttr[8:20], txID)
+		if _, err := parseSTUNResponse(noAttr, txID); err == nil {
+			t.Fatal("expected error when XOR-MAPPED-ADDRESS is absent")
+		}
+	})
+}
+
+// TestNew covers matrix item 7: New returns a Bind with a non-zero sessionID,
+// a RecvCh of the requested capacity, and open == false before Open.
+func TestNew(t *testing.T) {
+	const bufSize = 16
+	b := New(nil, bufSize)
+
+	if b.sessionID == 0 {
+		t.Fatal("sessionID is zero; expected a random non-zero identifier")
+	}
+	if got := cap(b.RecvCh); got != bufSize {
+		t.Fatalf("RecvCh capacity = %d, want %d", got, bufSize)
+	}
+	if b.open {
+		t.Fatal("open is true before Open() was called")
+	}
+}
+
+// TestUpgradeUDP_BadTokenLen covers matrix item 8: a wrong-length token is
+// rejected before any socket is opened or any UDP state is mutated.
+func TestUpgradeUDP_BadTokenLen(t *testing.T) {
+	b := New(nil, 4)
+
+	err := b.UpgradeUDP("127.0.0.1", 12345, []byte{1, 2, 3})
+	if err == nil {
+		t.Fatal("expected error for a 3-byte token")
+	}
+	if b.UDPActive() {
+		t.Fatal("UDPActive() is true after a rejected UpgradeUDP")
+	}
+	if b.udpConn != nil {
+		t.Fatal("udpConn was opened despite the token being rejected")
+	}
+}
+
+// TestClose_Idempotent covers matrix item 9: Close is safe before Open and
+// safe to call twice.
+func TestClose_Idempotent(t *testing.T) {
+	b := New(nil, 4)
+
+	if err := b.Close(); err != nil {
+		t.Fatalf("Close before Open returned error: %v", err)
+	}
+	if err := b.Close(); err != nil {
+		t.Fatalf("second Close returned error: %v", err)
+	}
+}
+
+// TestConnAdapters covers matrix item 10: the trivial conn.Bind adapters.
+func TestConnAdapters(t *testing.T) {
+	b := New(nil, 4)
+
+	if got := b.BatchSize(); got != 1 {
+		t.Fatalf("BatchSize() = %d, want 1", got)
+	}
+	if err := b.SetMark(42); err != nil {
+		t.Fatalf("SetMark returned error: %v", err)
+	}
+	ep, err := b.ParseEndpoint("anything")
+	if err != nil {
+		t.Fatalf("ParseEndpoint returned error: %v", err)
+	}
+	if ep == nil {
+		t.Fatal("ParseEndpoint returned a nil endpoint")
+	}
+}
+
+// TestParseHeaderRoundTrip is a small sanity check that the relay helpers the
+// matrix relies on frame and parse a payload symmetrically, guarding the
+// framed/unframed assertions in the Tier B WS tests.
+func TestParseHeaderRoundTrip(t *testing.T) {
+	payload := []byte("wireguard-ciphertext")
+	framed := relay.BuildDataFrame(payload, 0, 0x11223344)
+	_, flags, sid, got, ok := relay.ParseHeader(framed)
+	if !ok {
+		t.Fatal("ParseHeader returned not-ok on a BuildDataFrame frame")
+	}
+	if flags != relay.FlagData {
+		t.Fatalf("flags = 0x%02x, want FlagData", flags)
+	}
+	if sid != 0x11223344 {
+		t.Fatalf("sessionID = 0x%08x, want 0x11223344", sid)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("payload = %q, want %q", got, payload)
+	}
+}

--- a/internal/wsbind/bind_udp_test.go
+++ b/internal/wsbind/bind_udp_test.go
@@ -1,0 +1,483 @@
+package wsbind
+
+import (
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"github.com/paulmooreparks/tela/internal/relay"
+)
+
+// newUDPListener binds a loopback UDP socket on an ephemeral port and closes
+// it at test end. Used as the Bind's own socket, the fake hub, the fake peer,
+// and the fake STUN server across the Tier B matrix.
+func newUDPListener(t *testing.T) *net.UDPConn {
+	t.Helper()
+	c, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	if err != nil {
+		t.Fatalf("ListenUDP: %v", err)
+	}
+	t.Cleanup(func() { c.Close() })
+	return c
+}
+
+func udpAddr(c *net.UDPConn) *net.UDPAddr { return c.LocalAddr().(*net.UDPAddr) }
+
+// recvWithin waits up to d for a datagram on ch. It is the positive-path
+// event wait; negative paths pass a short window and assert !ok.
+func recvWithin(ch <-chan []byte, d time.Duration) ([]byte, bool) {
+	select {
+	case b := <-ch:
+		return b, true
+	case <-time.After(d):
+		return nil, false
+	}
+}
+
+// hubDataFrame builds a hub-relayed datagram: [token][relay header][payload].
+func hubDataFrame(token, payload []byte) []byte {
+	hdr := relay.BuildDataFrame(payload, 0, 0)
+	out := make([]byte, 0, len(token)+len(hdr))
+	out = append(out, token...)
+	out = append(out, hdr...)
+	return out
+}
+
+// startFakeHub answers the UpgradeUDP probe handshake. On each [token]["PROBE"]
+// it publishes the client's source address on the returned channel and replies
+// [replyToken][replyWord]. Passing a mismatched token or a non-"READY" word
+// drives the negative handshake cases.
+func startFakeHub(t *testing.T, replyToken []byte, replyWord string) (*net.UDPConn, <-chan *net.UDPAddr) {
+	t.Helper()
+	hub := newUDPListener(t)
+	addrCh := make(chan *net.UDPAddr, 1)
+	go func() {
+		buf := make([]byte, 1500)
+		for {
+			n, addr, err := hub.ReadFromUDP(buf)
+			if err != nil {
+				return
+			}
+			if n >= tokenLen && string(buf[tokenLen:n]) == probeWord {
+				select {
+				case addrCh <- addr:
+				default:
+				}
+				reply := append(append([]byte{}, replyToken...), []byte(replyWord)...)
+				hub.WriteToUDP(reply, addr)
+			}
+		}
+	}()
+	return hub, addrCh
+}
+
+func testToken() []byte { return []byte{1, 2, 3, 4, 5, 6, 7, 8} }
+
+// TestUpgradeUDP_HappyPath covers matrix item 11: probe/READY round trip
+// activates UDP, and a subsequent hub-tagged frame arrives on RecvCh stripped.
+func TestUpgradeUDP_HappyPath(t *testing.T) {
+	b, _, cleanup := newBind(t, 8)
+	defer cleanup()
+	defer b.Close()
+
+	token := testToken()
+	hub, addrCh := startFakeHub(t, token, readyWord)
+
+	if err := b.UpgradeUDP("127.0.0.1", udpAddr(hub).Port, token); err != nil {
+		t.Fatalf("UpgradeUDP: %v", err)
+	}
+	if !b.UDPActive() {
+		t.Fatal("UDPActive() false after a successful upgrade")
+	}
+
+	var clientAddr *net.UDPAddr
+	select {
+	case clientAddr = <-addrCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("hub never observed the probe")
+	}
+
+	payload := []byte("relayed-wg")
+	if _, err := hub.WriteToUDP(hubDataFrame(token, payload), clientAddr); err != nil {
+		t.Fatalf("hub data send: %v", err)
+	}
+	got, ok := recvWithin(b.RecvCh, 2*time.Second)
+	if !ok {
+		t.Fatal("relayed datagram never arrived on RecvCh")
+	}
+	if string(got) != "relayed-wg" {
+		t.Fatalf("RecvCh payload = %q, want %q", got, "relayed-wg")
+	}
+}
+
+// TestUpgradeUDP_ProbeTimeout covers matrix item 12: a silent hub yields an
+// error after the 2s probe deadline; UDP stays inactive. Real-timer negative
+// path, run in parallel with the other two.
+func TestUpgradeUDP_ProbeTimeout(t *testing.T) {
+	t.Parallel()
+	b, _, cleanup := newBind(t, 4)
+	defer cleanup()
+
+	hub := newUDPListener(t) // never replies
+	start := time.Now()
+	err := b.UpgradeUDP("127.0.0.1", udpAddr(hub).Port, testToken())
+	if err == nil {
+		t.Fatal("expected a probe-timeout error")
+	}
+	if elapsed := time.Since(start); elapsed < time.Second {
+		t.Fatalf("UpgradeUDP returned after %s; expected it to wait out the ~2s deadline", elapsed)
+	}
+	if b.UDPActive() {
+		t.Fatal("UDPActive() true after a probe timeout")
+	}
+}
+
+// TestUpgradeUDP_TokenMismatch covers matrix item 13: a READY reply carrying
+// the wrong token is rejected.
+func TestUpgradeUDP_TokenMismatch(t *testing.T) {
+	b, _, cleanup := newBind(t, 4)
+	defer cleanup()
+
+	hub, _ := startFakeHub(t, []byte{9, 9, 9, 9, 9, 9, 9, 9}, readyWord)
+	if err := b.UpgradeUDP("127.0.0.1", udpAddr(hub).Port, testToken()); err == nil {
+		t.Fatal("expected a token-mismatch error")
+	}
+	if b.UDPActive() {
+		t.Fatal("UDPActive() true after a token mismatch")
+	}
+}
+
+// TestUpgradeUDP_MalformedReply covers matrix item 14: a wrong-length reply is
+// rejected.
+func TestUpgradeUDP_MalformedReply(t *testing.T) {
+	b, _, cleanup := newBind(t, 4)
+	defer cleanup()
+
+	hub, _ := startFakeHub(t, testToken(), "READ") // 4-byte word, wrong length
+	if err := b.UpgradeUDP("127.0.0.1", udpAddr(hub).Port, testToken()); err == nil {
+		t.Fatal("expected a malformed-reply error")
+	}
+	if b.UDPActive() {
+		t.Fatal("UDPActive() true after a malformed reply")
+	}
+}
+
+// TestUDPReader_BadMagicDropped covers matrix item 15: a hub-sourced frame
+// with a bad magic byte is dropped, not delivered to RecvCh.
+func TestUDPReader_BadMagicDropped(t *testing.T) {
+	b, _, cleanup := newBind(t, 8)
+	defer cleanup()
+	defer b.Close()
+
+	bindSock := newUDPListener(t)
+	hub := newUDPListener(t)
+	token := testToken()
+	// Field injection happens-before the reader goroutine starts (race-safe).
+	b.udpConn = bindSock
+	b.udpHubAddr = udpAddr(hub)
+	b.udpToken = token
+	go b.udpReader()
+
+	bad := append(append([]byte{}, token...), make([]byte, relay.HeaderLen+8)...)
+	bad[tokenLen] = 0x00 // not relay.Magic
+	if _, err := hub.WriteToUDP(bad, udpAddr(bindSock)); err != nil {
+		t.Fatalf("hub send: %v", err)
+	}
+	if _, ok := recvWithin(b.RecvCh, 200*time.Millisecond); ok {
+		t.Fatal("bad-magic frame reached RecvCh; it must be dropped")
+	}
+}
+
+// TestUDPReader_TPunchActivatesDirect covers matrix item 16: a TPUNCH from a
+// non-hub source records directAddr and unblocks AttemptDirect.
+func TestUDPReader_TPunchActivatesDirect(t *testing.T) {
+	b, _, cleanup := newBind(t, 8)
+	defer cleanup()
+	defer b.Close()
+
+	bindSock := newUDPListener(t)
+	hub := newUDPListener(t)
+	peer := newUDPListener(t)
+	b.udpConn = bindSock
+	b.udpHubAddr = udpAddr(hub)
+	b.udpToken = testToken()
+	go b.udpReader()
+
+	// The peer answers the bind's TPUNCH probe with its own TPUNCH.
+	go func() {
+		buf := make([]byte, 1500)
+		n, addr, err := peer.ReadFromUDP(buf)
+		if err != nil {
+			return
+		}
+		if string(buf[:n]) == directProbeMsg {
+			peer.WriteToUDP([]byte(directProbeMsg), addr)
+		}
+	}()
+
+	if err := b.AttemptDirect(udpAddr(peer).String()); err != nil {
+		t.Fatalf("AttemptDirect: %v", err)
+	}
+	if !b.DirectActive() {
+		t.Fatal("DirectActive() false after a successful punch")
+	}
+	b.directMu.RLock()
+	got := b.directAddr
+	b.directMu.RUnlock()
+	if got == nil || got.Port != udpAddr(peer).Port {
+		t.Fatalf("directAddr = %v, want peer port %d", got, udpAddr(peer).Port)
+	}
+}
+
+// TestUDPReader_DirectDatagramDelivered covers matrix item 17: once direct is
+// active, a header-framed datagram from the known peer arrives on RecvCh.
+func TestUDPReader_DirectDatagramDelivered(t *testing.T) {
+	b, _, cleanup := newBind(t, 8)
+	defer cleanup()
+	defer b.Close()
+
+	bindSock := newUDPListener(t)
+	peer := newUDPListener(t)
+	b.udpConn = bindSock
+	b.directAddr = udpAddr(peer)
+	b.directActive = true
+	go b.udpReader()
+
+	payload := []byte("direct-wg-payload")
+	// sessionID chosen so bytes 4-7 do not collide with the STUN magic cookie.
+	frame := relay.BuildDataFrame(payload, 0, 0x22334455)
+	if _, err := peer.WriteToUDP(frame, udpAddr(bindSock)); err != nil {
+		t.Fatalf("peer send: %v", err)
+	}
+	got, ok := recvWithin(b.RecvCh, 2*time.Second)
+	if !ok {
+		t.Fatal("direct datagram never arrived on RecvCh")
+	}
+	if string(got) != "direct-wg-payload" {
+		t.Fatalf("RecvCh payload = %q, want %q", got, "direct-wg-payload")
+	}
+}
+
+// TestUDPReader_UnknownSourceDropped covers matrix item 18: a packet from an
+// unknown source that is neither STUN nor TPUNCH is dropped from every channel.
+func TestUDPReader_UnknownSourceDropped(t *testing.T) {
+	b, _, cleanup := newBind(t, 8)
+	defer cleanup()
+	defer b.Close()
+
+	bindSock := newUDPListener(t)
+	hub := newUDPListener(t)
+	stranger := newUDPListener(t)
+	b.udpConn = bindSock
+	b.udpHubAddr = udpAddr(hub)
+	go b.udpReader()
+
+	// 30 bytes: bytes 4-7 are 0xABABABAB (not the STUN cookie), length is not 6
+	// (not TPUNCH), and the source is neither hub nor direct peer.
+	junk := make([]byte, 30)
+	for i := range junk {
+		junk[i] = 0xAB
+	}
+	if _, err := stranger.WriteToUDP(junk, udpAddr(bindSock)); err != nil {
+		t.Fatalf("stranger send: %v", err)
+	}
+	if _, ok := recvWithin(b.RecvCh, 200*time.Millisecond); ok {
+		t.Fatal("unknown-source packet reached RecvCh")
+	}
+	if n := len(b.stunCh); n != 0 {
+		t.Fatalf("stunCh received %d packets; want 0", n)
+	}
+	if n := len(b.punchCh); n != 0 {
+		t.Fatalf("punchCh received %d signals; want 0", n)
+	}
+}
+
+// TestAttemptDirect_Timeout covers matrix item 19: a peer that never answers
+// TPUNCH yields an error after the 5s punch timeout. Real-timer negative path.
+func TestAttemptDirect_Timeout(t *testing.T) {
+	t.Parallel()
+	b, _, cleanup := newBind(t, 4)
+	defer cleanup()
+
+	bindSock := newUDPListener(t)
+	peer := newUDPListener(t) // drains implicitly, never answers
+	b.udpConn = bindSock
+
+	start := time.Now()
+	err := b.AttemptDirect(udpAddr(peer).String())
+	if err == nil {
+		t.Fatal("expected a hole-punch timeout error")
+	}
+	if elapsed := time.Since(start); elapsed < 4*time.Second {
+		t.Fatalf("AttemptDirect returned after %s; expected it to wait out the ~5s timeout", elapsed)
+	}
+	if b.DirectActive() {
+		t.Fatal("DirectActive() true after a punch timeout")
+	}
+}
+
+// TestSend_DirectPriority covers matrix item 20: with both direct and UDP
+// relay active, Send routes to the direct peer and never touches the hub socket.
+func TestSend_DirectPriority(t *testing.T) {
+	b, _, cleanup := newBind(t, 4)
+	defer cleanup()
+
+	bindSock := newUDPListener(t)
+	peer := newUDPListener(t)
+	hub := newUDPListener(t)
+	b.udpConn = bindSock
+	b.directActive = true
+	b.directAddr = udpAddr(peer)
+	b.udpActive = true
+	b.udpHubAddr = udpAddr(hub)
+	b.udpToken = testToken()
+
+	if err := b.Send([][]byte{[]byte("priority-wg")}, &endpoint{}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	// The direct peer receives a [header][payload] frame.
+	buf := make([]byte, 1500)
+	if err := peer.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatalf("SetReadDeadline: %v", err)
+	}
+	n, _, err := peer.ReadFromUDP(buf)
+	if err != nil {
+		t.Fatalf("peer ReadFromUDP: %v", err)
+	}
+	_, flags, _, body, ok := relay.ParseHeader(buf[:n])
+	if !ok || flags != relay.FlagData || string(body) != "priority-wg" {
+		t.Fatalf("peer frame malformed: ok=%v flags=0x%02x body=%q", ok, flags, body)
+	}
+
+	// The hub relay socket receives nothing.
+	if err := hub.SetReadDeadline(time.Now().Add(200 * time.Millisecond)); err != nil {
+		t.Fatalf("SetReadDeadline: %v", err)
+	}
+	if n2, _, err := hub.ReadFromUDP(buf); err == nil {
+		t.Fatalf("hub relay socket received %d bytes; the direct path must not touch it", n2)
+	}
+}
+
+// TestSend_UDPWriteFailFallsBackToWS covers matrix item 21: a failed UDP-relay
+// write falls back to WebSocket and flips udpActive false.
+func TestSend_UDPWriteFailFallsBackToWS(t *testing.T) {
+	b, peer, cleanup := newBind(t, 4)
+	defer cleanup()
+
+	bindSock := newUDPListener(t)
+	hub := newUDPListener(t)
+	b.udpActive = true
+	b.udpConn = bindSock
+	b.udpHubAddr = udpAddr(hub)
+	b.udpToken = testToken()
+	bindSock.Close() // force WriteToUDP to fail
+
+	if err := b.Send([][]byte{[]byte("fallback-wg")}, &endpoint{}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	mt, msg := readWSMessage(t, peer, 2*time.Second)
+	if mt != websocket.BinaryMessage {
+		t.Fatalf("message type = %d, want BinaryMessage", mt)
+	}
+	_, flags, sid, body, ok := relay.ParseHeader(msg)
+	if !ok || flags != relay.FlagData || sid != b.sessionID || string(body) != "fallback-wg" {
+		t.Fatalf("WS frame malformed: ok=%v flags=0x%02x sid=0x%08x body=%q", ok, flags, sid, body)
+	}
+	if b.UDPActive() {
+		t.Fatal("udpActive still true after a UDP write failure")
+	}
+}
+
+// TestSend_UDPHealthTimeoutFallsBackToWS covers matrix item 22: a forged stale
+// lastUDPRecv against a recent lastUDPSend routes Send through WebSocket. No
+// real 60-second wait: the timestamps are stored directly.
+func TestSend_UDPHealthTimeoutFallsBackToWS(t *testing.T) {
+	b, peer, cleanup := newBind(t, 4)
+	defer cleanup()
+
+	bindSock := newUDPListener(t)
+	hub := newUDPListener(t)
+	b.udpActive = true
+	b.udpConn = bindSock
+	b.udpHubAddr = udpAddr(hub)
+	b.udpToken = testToken()
+	atomic.StoreInt64(&b.lastUDPRecv, time.Now().Add(-2*udpHealthTimeout).UnixNano())
+	atomic.StoreInt64(&b.lastUDPSend, time.Now().UnixNano())
+
+	if err := b.Send([][]byte{[]byte("healthfail-wg")}, &endpoint{}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	mt, msg := readWSMessage(t, peer, 2*time.Second)
+	if mt != websocket.BinaryMessage {
+		t.Fatalf("message type = %d, want BinaryMessage", mt)
+	}
+	_, flags, _, body, ok := relay.ParseHeader(msg)
+	if !ok || flags != relay.FlagData || string(body) != "healthfail-wg" {
+		t.Fatalf("WS frame malformed: ok=%v flags=0x%02x body=%q", ok, flags, body)
+	}
+	if b.UDPActive() {
+		t.Fatal("udpActive still true after a UDP health timeout")
+	}
+}
+
+// TestSTUNDiscover_HappyPath covers matrix item 26: STUNDiscover against a
+// local fake responder returns the parsed reflexive address.
+func TestSTUNDiscover_HappyPath(t *testing.T) {
+	b, _, cleanup := newBind(t, 4)
+	defer cleanup()
+	defer b.Close()
+
+	bindSock := newUDPListener(t)
+	b.udpConn = bindSock
+	go b.udpReader()
+
+	stun := newUDPListener(t)
+	b.stunAddr = udpAddr(stun).String()
+
+	go func() {
+		buf := make([]byte, 1500)
+		n, addr, err := stun.ReadFromUDP(buf)
+		if err != nil || n < 20 {
+			return
+		}
+		txID := append([]byte{}, buf[8:20]...)
+		resp := buildSTUNSuccess(txID, net.IPv4(203, 0, 113, 5), 55555)
+		stun.WriteToUDP(resp, addr)
+	}()
+
+	got, err := b.STUNDiscover()
+	if err != nil {
+		t.Fatalf("STUNDiscover: %v", err)
+	}
+	if got != "203.0.113.5:55555" {
+		t.Fatalf("reflexive address = %q, want %q", got, "203.0.113.5:55555")
+	}
+}
+
+// TestSTUNDiscover_Timeout covers matrix item 27: a silent STUN responder
+// yields an error after the 3s timeout. Real-timer negative path.
+func TestSTUNDiscover_Timeout(t *testing.T) {
+	t.Parallel()
+	b, _, cleanup := newBind(t, 4)
+	defer cleanup()
+	defer b.Close()
+
+	bindSock := newUDPListener(t)
+	b.udpConn = bindSock
+	go b.udpReader()
+
+	stun := newUDPListener(t) // never replies
+	b.stunAddr = udpAddr(stun).String()
+
+	start := time.Now()
+	if _, err := b.STUNDiscover(); err == nil {
+		t.Fatal("expected a STUN timeout error")
+	}
+	if elapsed := time.Since(start); elapsed < 2*time.Second {
+		t.Fatalf("STUNDiscover returned after %s; expected it to wait out the ~3s timeout", elapsed)
+	}
+}

--- a/internal/wsbind/bind_ws_test.go
+++ b/internal/wsbind/bind_ws_test.go
@@ -1,0 +1,288 @@
+package wsbind
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"github.com/paulmooreparks/tela/internal/relay"
+)
+
+// newWSPair stands up an httptest WebSocket server that accepts a single
+// upgrade and returns the client-side and server-side *websocket.Conn plus a
+// cleanup func. The client side is the Bind's transport; the server side
+// stands in for the hub/peer end so tests can inspect what the Bind wrote.
+func newWSPair(t *testing.T) (client, server *websocket.Conn, cleanup func()) {
+	t.Helper()
+	upgrader := websocket.Upgrader{CheckOrigin: func(_ *http.Request) bool { return true }}
+	serverCh := make(chan *websocket.Conn, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		serverCh <- c
+	}))
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	client, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		srv.Close()
+		t.Fatalf("dial WebSocket: %v", err)
+	}
+
+	select {
+	case server = <-serverCh:
+	case <-time.After(2 * time.Second):
+		client.Close()
+		srv.Close()
+		t.Fatal("server-side upgrade did not complete")
+	}
+
+	cleanup = func() {
+		client.Close()
+		server.Close()
+		srv.Close()
+	}
+	return client, server, cleanup
+}
+
+// newBind constructs a Bind over a fresh WS pair. The returned peer conn is
+// the server-side end (the fake hub/peer). Used by every Tier B test that
+// needs a real, if mostly inert, WebSocket leg.
+func newBind(t *testing.T, bufSize int) (b *Bind, peer *websocket.Conn, cleanup func()) {
+	t.Helper()
+	client, server, cleanup := newWSPair(t)
+	return New(client, bufSize), server, cleanup
+}
+
+// readWSMessage reads one message from conn with a bounded deadline, failing
+// the test rather than hanging if nothing arrives.
+func readWSMessage(t *testing.T, conn *websocket.Conn, budget time.Duration) (msgType int, data []byte) {
+	t.Helper()
+	if err := conn.SetReadDeadline(time.Now().Add(budget)); err != nil {
+		t.Fatalf("SetReadDeadline: %v", err)
+	}
+	mt, p, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("ReadMessage: %v", err)
+	}
+	return mt, p
+}
+
+// TestSendWS_And_ControlFrame_AreFramed covers matrix item 23's framed half:
+// sendWS and SendControlFrame each land on the peer as a binary relay frame
+// that ParseHeader accepts, with the expected flags and sessionID.
+func TestSendWS_And_ControlFrame_AreFramed(t *testing.T) {
+	b, peer, cleanup := newBind(t, 4)
+	defer cleanup()
+
+	t.Run("sendWS produces a DATA frame", func(t *testing.T) {
+		payload := []byte("wg-datagram")
+		if err := b.sendWS([][]byte{payload}); err != nil {
+			t.Fatalf("sendWS: %v", err)
+		}
+		mt, data := readWSMessage(t, peer, 2*time.Second)
+		if mt != websocket.BinaryMessage {
+			t.Fatalf("message type = %d, want BinaryMessage", mt)
+		}
+		_, flags, sid, body, ok := relay.ParseHeader(data)
+		if !ok {
+			t.Fatal("ParseHeader not-ok on sendWS output")
+		}
+		if flags != relay.FlagData {
+			t.Fatalf("flags = 0x%02x, want FlagData", flags)
+		}
+		if sid != b.sessionID {
+			t.Fatalf("sessionID = 0x%08x, want 0x%08x", sid, b.sessionID)
+		}
+		if string(body) != "wg-datagram" {
+			t.Fatalf("payload = %q, want %q", body, "wg-datagram")
+		}
+	})
+
+	t.Run("SendControlFrame produces a CONTROL frame", func(t *testing.T) {
+		if err := b.SendControlFrame([]byte{relay.ControlKeepaliveReq}); err != nil {
+			t.Fatalf("SendControlFrame: %v", err)
+		}
+		mt, data := readWSMessage(t, peer, 2*time.Second)
+		if mt != websocket.BinaryMessage {
+			t.Fatalf("message type = %d, want BinaryMessage", mt)
+		}
+		_, flags, sid, body, ok := relay.ParseHeader(data)
+		if !ok {
+			t.Fatal("ParseHeader not-ok on SendControlFrame output")
+		}
+		if flags != relay.FlagControl {
+			t.Fatalf("flags = 0x%02x, want FlagControl", flags)
+		}
+		if sid != b.sessionID {
+			t.Fatalf("sessionID = 0x%08x, want 0x%08x", sid, b.sessionID)
+		}
+		if len(body) != 1 || body[0] != relay.ControlKeepaliveReq {
+			t.Fatalf("control payload = %v, want [%d]", body, relay.ControlKeepaliveReq)
+		}
+	})
+}
+
+// TestSendText_IsUnframedJSON covers matrix item 23's unframed half: SendText
+// rides the WS text channel as raw JSON, carrying no relay header. This pins
+// the framed/unframed split (see resolved open_question 7731).
+func TestSendText_IsUnframedJSON(t *testing.T) {
+	b, peer, cleanup := newBind(t, 4)
+	defer cleanup()
+
+	msg := []byte(`{"type":"keepalive"}`)
+	if err := b.SendText(msg); err != nil {
+		t.Fatalf("SendText: %v", err)
+	}
+
+	mt, data := readWSMessage(t, peer, 2*time.Second)
+	if mt != websocket.TextMessage {
+		t.Fatalf("message type = %d, want TextMessage", mt)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("payload does not decode as JSON: %v", err)
+	}
+	if decoded["type"] != "keepalive" {
+		t.Fatalf("decoded type = %v, want keepalive", decoded["type"])
+	}
+	if _, _, _, _, ok := relay.ParseHeader(data); ok {
+		t.Fatal("relay.ParseHeader accepted an unframed TextMessage; the split is not pinned")
+	}
+}
+
+// drainWS reads and discards messages from conn until it errors (conn closed),
+// so the Bind's writes never block on a full send buffer. It does NOT feed the
+// keepalive response channel; callers that want responses wire that separately.
+func drainWS(conn *websocket.Conn) {
+	go func() {
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}()
+}
+
+// TestStartSessionKeepalive_HappyPath covers matrix item 24: with a short
+// injected interval/timeout and keepalive responses flowing, closeFn is never
+// called.
+func TestStartSessionKeepalive_HappyPath(t *testing.T) {
+	b, peer, cleanup := newBind(t, 4)
+	defer cleanup()
+
+	var closed int32
+	sawReq := make(chan struct{}, 1)
+
+	interval := 20 * time.Millisecond
+	timeout := 80 * time.Millisecond
+	respCh, stop := b.StartSessionKeepalive(func() { atomic.AddInt32(&closed, 1) }, interval, timeout)
+	defer stop()
+
+	// Peer side: read each keepalive request frame and immediately feed the
+	// response channel, keeping the loop's waiting flag reset before timeout.
+	go func() {
+		for {
+			mt, data, err := peer.ReadMessage()
+			if err != nil {
+				return
+			}
+			if mt == websocket.BinaryMessage {
+				if _, flags, _, body, ok := relay.ParseHeader(data); ok &&
+					flags == relay.FlagControl && len(body) == 1 && body[0] == relay.ControlKeepaliveReq {
+					select {
+					case sawReq <- struct{}{}:
+					default:
+					}
+					respCh <- struct{}{}
+				}
+			}
+		}
+	}()
+
+	// Confirm the round trip actually happened at least once.
+	select {
+	case <-sawReq:
+	case <-time.After(2 * time.Second):
+		t.Fatal("no keepalive request observed on the WS peer end")
+	}
+
+	// Observe several timeout windows; closeFn must never fire while responses flow.
+	time.Sleep(250 * time.Millisecond)
+	if n := atomic.LoadInt32(&closed); n != 0 {
+		t.Fatalf("closeFn called %d times on the happy path; want 0", n)
+	}
+}
+
+// TestStartSessionKeepalive_Characterization covers matrix item 25: a
+// two-aspect characterization of the tela-69 timeout defect.
+//
+// Aspect (a) pins current behavior: bind.go's keepalive loop resends and
+// resets its own lastReqAt on every tick, so with interval < timeout (the
+// production ratio) time.Since(lastReqAt) is always ~interval and the
+// `waiting && elapsed >= timeout` branch is unreachable. closeFn therefore
+// never fires even across many timeout windows with no responses. When
+// tela-69 lands and the loop starts the clock once per outstanding request,
+// this aspect flips to asserting closeFn fires within the timeout budget.
+//
+// Aspect (b) proves the close mechanism itself works: with interval >=
+// timeout, the elapsed check can succeed and closeFn fires exactly once.
+func TestStartSessionKeepalive_Characterization(t *testing.T) {
+	t.Run("interval<timeout never fires (tela-69)", func(t *testing.T) {
+		b, peer, cleanup := newBind(t, 4)
+		defer cleanup()
+		drainWS(peer) // read requests, never respond
+
+		var closed int32
+		interval := 50 * time.Millisecond
+		timeout := 100 * time.Millisecond
+		_, stop := b.StartSessionKeepalive(func() { atomic.AddInt32(&closed, 1) }, interval, timeout)
+		defer stop()
+
+		// Five timeout windows with zero responses. Per tela-69, closeFn is
+		// unreachable at this ratio and must stay uncalled.
+		time.Sleep(500 * time.Millisecond)
+		if n := atomic.LoadInt32(&closed); n != 0 {
+			t.Fatalf("closeFn fired %d times at interval<timeout; tela-69 says it must stay 0", n)
+		}
+	})
+
+	t.Run("interval>=timeout fires exactly once", func(t *testing.T) {
+		b, peer, cleanup := newBind(t, 4)
+		defer cleanup()
+		drainWS(peer) // read requests, never respond
+
+		var closed int32
+		fired := make(chan struct{}, 1)
+		interval := 100 * time.Millisecond
+		timeout := 50 * time.Millisecond
+		_, stop := b.StartSessionKeepalive(func() {
+			atomic.AddInt32(&closed, 1)
+			select {
+			case fired <- struct{}{}:
+			default:
+			}
+		}, interval, timeout)
+		defer stop()
+
+		select {
+		case <-fired:
+		case <-time.After(2 * time.Second):
+			t.Fatal("closeFn never fired at interval>=timeout")
+		}
+		// The goroutine returns after closeFn, so a second call is impossible;
+		// confirm the count stays at one over a further window.
+		time.Sleep(250 * time.Millisecond)
+		if n := atomic.LoadInt32(&closed); n != 1 {
+			t.Fatalf("closeFn fired %d times; want exactly 1", n)
+		}
+	})
+}


### PR DESCRIPTION
First test coverage for internal/wsbind per GitHub #12: STUN response parsing negatives, the UpgradeUDP probe/READY handshake contract, udpReader demultiplexing across hub frames, TPUNCH activation, direct-peer datagrams and unknown-source drops, Send priority and both WebSocket fallbacks (write failure and forged health timeout), keepalive round trips, and STUN discovery against a local fake responder. Two test-only production hooks with zero wire-byte changes: an unexported STUN address override and a parameterized StartSessionKeepalive, with both call sites passing the existing production constants. Includes a two-aspect characterization of the keepalive dead-session defect tracked as board card tela-69; the live-NAT tier is board card tela-70.

Card: tela-18
Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)