### PR TITLE
docs: Comprehensive Editorial Pass Over the Book

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -4,61 +4,63 @@
 
 # Getting Started
 
-- [What Tela is](getting-started/what-tela-is.md)
+- [What Tela Is](getting-started/what-tela-is.md)
 - [Installation](getting-started/installation.md)
-- [First connection: hello, hub](getting-started/first-connection.md)
+- [First Connection](getting-started/first-connection.md)
 
 # User Guide
 
-- [The three binaries](guide/three-binaries.md)
-- [Credentials and pairing](guide/credentials.md)
-- [Connection profiles](guide/profiles.md)
-- [Hub directories and portals](guide/directories.md)
-- [The path gateway](guide/gateway.md)
-- [File sharing](guide/file-sharing.md)
+- [The Three Binaries](guide/three-binaries.md)
+- [Credentials and Pairing](guide/credentials.md)
+- [Connection Profiles](guide/profiles.md)
+- [Hub Directories and Portals](guide/directories.md)
+- [The Path Gateway](guide/gateway.md)
+- [File Sharing](guide/file-sharing.md)
 - [Upstreams](guide/upstreams.md)
-- [Hub administration](guide/admin.md)
-- [Hub web console](guide/hub-console.md)
-- [TelaVisor desktop app](guide/telavisor.md)
+- [Hub Administration](guide/admin.md)
+- [Hub Web Console](guide/hub-console.md)
+- [TelaVisor Desktop App](guide/telavisor.md)
 
 # How-to Guides
 
-- [Self-update and release channels](howto/channels.md)
-- [Run a hub on the public internet](howto/hub.md)
-- [Run an agent](howto/telad.md)
-- [Run Tela as an OS service](howto/services.md)
-- [Set up a path-based gateway](howto/gateway.md)
-- [Networking caveats](howto/networking.md)
+- [Self-Update and Release Channels](howto/channels.md)
+- [Run a Hub on the Public Internet](howto/hub.md)
+- [Run an Agent](howto/telad.md)
+- [Run Tela as an OS Service](howto/services.md)
+- [Set Up a Path-Based Gateway](howto/gateway.md)
+- [Networking Caveats](howto/networking.md)
 
 # Use Cases
 
-- [Personal cloud](use-cases/personal-cloud.md)
-- [Private web application](use-cases/private-web-app.md)
-- [Production access](use-cases/production-access.md)
-- [Distributed teams](use-cases/distributed-teams.md)
-- [MSP / IT support](use-cases/msp-it-support.md)
-- [Education labs](use-cases/education-labs.md)
-- [IoT / edge](use-cases/iot-edge.md)
+- [Personal Cloud](use-cases/personal-cloud.md)
+- [Private Web Application](use-cases/private-web-app.md)
+- [Production Access](use-cases/production-access.md)
+- [Distributed Teams](use-cases/distributed-teams.md)
+- [MSP and IT Support](use-cases/msp-it-support.md)
+- [Education Labs](use-cases/education-labs.md)
+- [IoT and Edge Devices](use-cases/iot-edge.md)
 
 # Operations
 
-- [Release process](ops/release-process.md)
+- [Release Process](ops/release-process.md)
+- [Roadmap to 1.0](ops/roadmap.md)
+- [Status: Design vs. Implementation](ops/status.md)
 
 # Design Rationale
 
-- [Why a connectivity fabric](architecture/design.md)
-- [Remote administration](architecture/remote-admin.md)
-- [File sharing](architecture/file-sharing.md)
+- [Why a Connectivity Fabric](architecture/design.md)
+- [Remote Administration](architecture/remote-admin.md)
+- [File Sharing](architecture/file-sharing.md)
 - [Gateways](architecture/gateway.md)
 
 ---
 
 # Appendices
 
-- [A. CLI reference](guide/reference.md)
-- [B. Configuration file reference](guide/configuration.md)
-- [C. Access model](architecture/access-model.md)
-- [D. Portal protocol](architecture/portal-protocol.md)
+- [A. CLI Reference](guide/reference.md)
+- [B. Configuration File Reference](guide/configuration.md)
+- [C. Access Model](architecture/access-model.md)
+- [D. Portal Protocol](architecture/portal-protocol.md)
 - [E. Tela Design Language](architecture/tdl.md)
 - [F. Glossary](glossary.md)
 

--- a/book/src/architecture/access-model.md
+++ b/book/src/architecture/access-model.md
@@ -1,4 +1,4 @@
-# Appendix C: Access model
+# Appendix C: Access Model
 
 This appendix is the reference for Tela's token-based access control model: the four roles, the per-machine permissions, and how the unified `/api/admin/access` endpoint joins tokens and permissions into a single resource.
 

--- a/book/src/architecture/design.md
+++ b/book/src/architecture/design.md
@@ -1,8 +1,8 @@
-# Why a connectivity fabric
+# Why a Connectivity Fabric
 
 Tela ships as three small binaries. It uses WireGuard but not the kernel driver. Its hub relays traffic without reading it. These are not defaults that fell out of convenience: each is a deliberate choice with a specific alternative that was considered and rejected. This chapter explains the three decisions that shaped the architecture.
 
-## Three binaries, not one
+## Three Binaries, Not One
 
 Tela could have been a single binary run in different modes: `tela --mode agent`, `tela --mode hub`, `tela --mode client`. The code would be simpler and distribution easier. The problem is that a single binary conflates trust domains.
 
@@ -12,7 +12,7 @@ Separate binaries make the separation structural. `telahubd` has no code path th
 
 The same argument applies to the split between client and agent. `tela` connects outbound and creates a local port binding. `telad` registers with a hub and exposes local services. They share a Go module but are distinct processes with distinct privilege requirements and distinct deployment contexts. A machine can run an agent without having the client binary, and vice versa.
 
-## The hub is a blind relay
+## The Hub Is a Blind Relay
 
 The hub could inspect WireGuard payloads. It could decrypt them, log the content, or apply policy based on what traffic flows through. This is how most commercial VPN concentrators work.
 
@@ -22,7 +22,7 @@ The reason is that a relay that *can* inspect traffic *will* be pressured to do 
 
 By making the hub blind structurally (no keys, no decryption code path, no policy hook), the security property is not a promise the hub operator makes. It is a consequence of what the software does.
 
-## No TUN, no root
+## No TUN, No Root
 
 Standard WireGuard works through a kernel TUN device. On Linux you create a `wg0` interface. On Windows you use the WireGuard kernel driver. On macOS you use the utun driver. All of these require elevated privileges: root on Unix, Administrator on Windows.
 

--- a/book/src/architecture/file-sharing.md
+++ b/book/src/architecture/file-sharing.md
@@ -1,14 +1,14 @@
-# File sharing
+# File Sharing
 
 Tela file sharing adds a sandboxed file transfer channel to the existing WireGuard tunnel between client and agent. Files flow through the same end-to-end encrypted connection that carries TCP service traffic. The hub remains a zero-knowledge relay: it sees opaque ciphertext regardless of whether the tunnel is carrying an SSH session or a file download.
 
-## Why not SSH or SFTP
+## Why Not SSH or SFTP
 
 The obvious alternative is to forward port 22 through the tunnel and use SFTP. That works, but it requires SSH to be installed and running on the target machine, the user to have shell credentials, and either a separate SFTP client or a tool that speaks SFTP. On Windows machines that expose only RDP, SSH is often absent. On locked-down servers, credentials may not exist for the operating user.
 
 A native file transfer channel removes all of those prerequisites. If `telad` is running and file sharing is enabled, any authorized Tela client can transfer files without SSH, without separate credentials, and without any software beyond `tela` itself.
 
-## The design principles
+## The Design Principles
 
 **Secure by default.** File sharing is disabled unless the agent operator adds a `shares:` entry to the machine config. No flag, no environment variable, and no runtime prompt can enable it implicitly. The operator must take a deliberate action.
 
@@ -20,23 +20,23 @@ A native file transfer channel removes all of those prerequisites. If `telad` is
 
 **Zero-knowledge relay.** File contents travel inside the WireGuard tunnel as ciphertext. The hub sees nothing different from any other tunnel traffic.
 
-## Why a dedicated port, not a new message type
+## Why a Dedicated Port, Not a New Message Type
 
 The relay transport between agent and hub carries WireGuard datagrams opaquely. Adding file operations as a new message type would mean teaching the transport to carry a second protocol alongside WireGuard traffic, with its own framing, flow control, and ordering. A TCP connection on a fixed port inside the WireGuard tunnel avoids all of that and inherits congestion control, flow control, and ordering from TCP for free.
 
 This is the same pattern used for service forwarding: the client dials a TCP port on the agent's tunnel IP. File sharing uses port 17377, which `telad` handles directly rather than forwarding to a local service.
 
-## The permission model
+## The Permission Model
 
 File sharing piggybacks on the existing `connect` permission. A token that can connect to a machine can use file sharing on that machine, subject to the agent's `shares:` configuration. A separate `canTransferFiles` permission would create a combinatorial matrix (connect with files, connect without files, files without connect) for limited practical benefit. The agent operator already controls the meaningful distinctions: writable or read-only, delete allowed or not, which extensions are permitted.
 
-## Chunked transfer
+## Chunked Transfer
 
 File data is sent in 16 KB chunks with explicit framing rather than as a raw byte stream. The reason is a real failure mode: on WSL2, the layered virtual networking stack (WSL2 network interface, WireGuard, relay transport) silently drops TCP segments above a certain effective size. A raw stream stalls without error when this happens. Chunked framing with a 30-second stall timeout makes the failure detectable and reportable instead of leaving the transfer hanging indefinitely.
 
 Each chunk is preceded by a `CHUNK <length>` header line. A zero-length chunk signals end-of-data. Both the sender and receiver validate a SHA-256 checksum against the total transfer.
 
-## Access from the client
+## Access from the Client
 
 The `tela files` subcommand provides a CLI interface: `ls`, `get`, `put`, `rm`, `mkdir`, `rename`, `mv`, and `info`. It requires an active tunnel established with `tela connect` and dials the file share port through the same netstack that handles service traffic.
 

--- a/book/src/architecture/gateway.md
+++ b/book/src/architecture/gateway.md
@@ -14,13 +14,13 @@ This rule is not a policy choice. It is a structural property of the design. A r
 
 A fifth instance, the multi-hop relay gateway, bridges sessions across more than one hub. It is the same primitive as the single-hop relay applied recursively: a hub that receives a paired session forwards it to an agent registered with a different hub, remaining blind to the payload at every hop. Each forwarding hub decrements a one-byte hop count (TTL) in the shared 7-byte frame header and drops the frame if the count reaches zero, which prevents forwarding loops without a routing protocol. The operator configures which destination hubs a bridging hub will dial via a `bridges:` section in `telahubd.yaml`; the bridging hub advertises the reachable machines through its own `/api/status` with a `reachableThrough` pointer so clients know which hub they are really talking to. For the full specification see [DESIGN-relay-gateway.md](https://github.com/paulmooreparks/tela/blob/main/DESIGN-relay-gateway.md).
 
-## Why the rule matters
+## Why the Rule Matters
 
 Every instance of the gateway primitive is content-blind except where the layer requires it. The path gateway is the one exception: it must read the URL path to route correctly. It reads nothing else. It does not authenticate, it does not transform, and it does not inspect request bodies or responses. Authentication is the hub's job, enforced before the session is established. Application-level auth is the application's job.
 
 This division of responsibility is what makes each gateway instance composable. A path gateway behind a relay gateway (the hub) behind a multi-hop relay has additive security properties at each layer. The blind-relay property of the hub does not require the path gateway to be blind; it requires only that each component know its layer and nothing else.
 
-## The path gateway
+## The Path Gateway
 
 The path gateway is the instance users encounter most often. It is an HTTP reverse proxy that runs inside `telad` on a single tunnel port. It matches incoming HTTP requests by URL path prefix and forwards them to local services.
 
@@ -52,7 +52,7 @@ Routes are matched by longest prefix first. A request to `/api/users` matches `/
 
 The gateway does not terminate TLS (the WireGuard tunnel already provides end-to-end encryption), does not load balance, does not transform requests or responses, and does not authenticate (that is the hub's job). It is a transparent path router.
 
-## Why no changes to the hub or client
+## Why No Changes to the Hub or Client
 
 The gateway is entirely contained within `telad`. The hub sees the gateway port as another port in the registration, no different from any other service. The client connects to port 8080 like any other port. No protocol changes are required, and no hub or client changes are needed.
 

--- a/book/src/architecture/portal-protocol.md
+++ b/book/src/architecture/portal-protocol.md
@@ -1,5 +1,5 @@
-# Appendix D: Portal protocol
+# Appendix D: Portal Protocol
 
-This appendix is the wire-level contract every Tela portal must implement. The [Hub directories and portals](../guide/directories.md) chapter in the User Guide describes portals from a deployment perspective. This appendix specifies what makes something a conformant portal in protocol terms.
+This appendix is the wire-level contract every Tela portal must implement. The [Hub Directories and Portals](../guide/directories.md) chapter in the User Guide describes portals from a deployment perspective. This appendix specifies what makes something a conformant portal in protocol terms.
 
 {{#include ../../../DESIGN-portal.md:3:}}

--- a/book/src/architecture/remote-admin.md
+++ b/book/src/architecture/remote-admin.md
@@ -1,8 +1,8 @@
-# Remote administration
+# Remote Administration
 
 Managing an agent or hub means changing its configuration, viewing its logs, restarting it, or updating it. There are several ways to implement this capability. Tela routes all management commands through the hub's existing admin API, rather than adding a direct management channel to each agent. This chapter explains why.
 
-## The outbound-only constraint
+## The Outbound-Only Constraint
 
 The agent is designed to open no inbound ports. It connects outbound to the hub's WebSocket endpoint on startup and holds that connection. Nothing connects to the agent; the agent connects to everything it needs.
 
@@ -10,7 +10,7 @@ Adding a direct management channel to the agent would require the agent to liste
 
 The management protocol is therefore built on the connection the agent already has: the control WebSocket to the hub. When an administrator sends a management command through the hub's admin API, the hub forwards the command to the target agent's control connection and returns the response. The agent never opens a new listener.
 
-## The access model is in the hub
+## The Access Model Is in the Hub
 
 The hub holds the access model: token roles, per-machine permissions, ownership. When a management command arrives at the hub's admin API, it is authenticated and authorized by the same machinery that governs data connections. An admin token that grants connect permission on a machine does not automatically grant manage permission; the permissions are distinct.
 
@@ -18,7 +18,7 @@ If management commands went directly to agents, each agent would need its own ac
 
 By routing management through the hub, the hub's access model covers management operations without additional machinery.
 
-## The portal composes naturally
+## The Portal Composes Naturally
 
 A portal like Awan Saya aggregates multiple hubs. It knows which hubs belong to which organization and which accounts have access to which hubs. It does not have direct network access to individual agent machines, nor should it.
 
@@ -30,13 +30,13 @@ The portal authenticates to each hub once, with an admin token. Through each hub
 
 If direct agent access were the design, a portal aggregating a thousand agents would need direct network paths and credentials for a thousand machines. The hub-mediated model means the portal needs credentials to dozens of hubs.
 
-## The audit trail is centralized
+## The Audit Trail Is Centralized
 
 When a management command passes through the hub, the hub records it: which identity issued the command, which machine it targeted, what the action was, and when. The agent records it locally as well. The hub log is the authoritative record for all commands that touched a given machine, regardless of whether they originated from the CLI, TelaVisor, or a portal.
 
 Direct agent access would produce logs scattered across every agent machine, with no central record of who did what across a fleet.
 
-## What the protocol looks like
+## What the Protocol Looks Like
 
 The management protocol adds two message types to the control WebSocket the agent already maintains:
 
@@ -45,6 +45,6 @@ The management protocol adds two message types to the control WebSocket the agen
 
 The hub maintains a pending-request map and returns the agent's response to the HTTP caller, with a 30-second timeout if the agent does not respond. From the caller's perspective, the hub admin API call is synchronous.
 
-Supported actions are `config-get`, `config-set`, `restart`, `logs`, and `update`. The agent advertises management support during registration. Agents that predate the management protocol do not receive requests and do not need to be updated before the hub is.
+Supported actions cover configuration (`config-get`, `config-set`), operations (`logs`, `restart`), and self-update (`update`, `update-status`, `update-channel`, plus the `channel-sources-*` family for custom channel sources). The agent advertises management support during registration. Agents that predate the management protocol do not receive requests and do not need to be updated before the hub is.
 
-For the full API reference, see [Appendix A: CLI reference](../guide/reference.md) and [Appendix B: Configuration file reference](../guide/configuration.md).
+For the full API reference, see [Appendix A: CLI Reference](../guide/reference.md) and [Appendix B: Configuration File Reference](../guide/configuration.md).

--- a/book/src/contributing.md
+++ b/book/src/contributing.md
@@ -1,11 +1,11 @@
 # Contributing
 
-Tela is an early-stage project moving fast. Contributions are welcome but
+Tela is an early-stage project moving fast. Contributions are welcome, but
 the bar is real: the code base has a "no cruft, no backward compatibility
 until 1.0" policy that drives a lot of the decisions, and PRs need to land
 clean (build, vet, gofmt, race-clean tests, no stray files).
 
-## Setting up a dev environment
+## Setting Up a Dev Environment
 
 ```bash
 git clone https://github.com/paulmooreparks/tela
@@ -16,41 +16,48 @@ go test ./...
 gofmt -l .          # should print nothing
 ```
 
+Continuous integration also enforces per-package test coverage floors on
+the security-critical packages; `go test ./...` passing locally is the main
+signal, and the coverage gate output in CI tells you exactly which package
+regressed if it trips.
+
 For TelaVisor specifically:
 
 ```bash
 cd cmd/telagui
-wails build         # outputs to ./build/bin/telavisor.exe
+wails build         # outputs to ./build/bin/
 ```
 
 You will need [Wails v2](https://wails.io/) installed.
 
-## What to read first
+## What to Read First
 
-- [CLAUDE.md](https://github.com/paulmooreparks/tela/blob/main/CLAUDE.md) --
+- [CLAUDE.md](https://github.com/paulmooreparks/tela/blob/main/CLAUDE.md):
   the project's guiding principles, coding conventions, API style, and the
   list of architectural review items
-- [Why a connectivity fabric](architecture/design.md) -- the design
+- [Why a Connectivity Fabric](architecture/design.md): the design
   rationale for the core architecture
-- [ROADMAP-1.0.md](https://github.com/paulmooreparks/tela/blob/main/ROADMAP-1.0.md) --
+- [ROADMAP-1.0.md](https://github.com/paulmooreparks/tela/blob/main/ROADMAP-1.0.md):
   the 1.0 readiness checklist (anything unticked is fair game)
-- [STATUS.md](https://github.com/paulmooreparks/tela/blob/main/STATUS.md) --
-  the live traceability matrix from design sections to implementation
+- [STATUS.md](https://github.com/paulmooreparks/tela/blob/main/STATUS.md):
+  the traceability matrix from design sections to implementation
 
-## Filing issues
+## Filing Issues
 
-Use the [GitHub issue tracker](https://github.com/paulmooreparks/tela/issues).
-For security issues, see [SECURITY.md](https://github.com/paulmooreparks/tela/blob/main/SECURITY.md)
-once it exists (it is on the 1.0 blocker list).
+Use the
+[GitHub issue tracker](https://github.com/paulmooreparks/tela/issues). For
+security issues, follow
+[SECURITY.md](https://github.com/paulmooreparks/tela/blob/main/SECURITY.md)
+rather than filing a public issue.
 
-## Pre-1.0 ground rules
+## Pre-1.0 Ground Rules
 
 - No backward-compatibility shims. If a name or shape is wrong, fix it
   everywhere in one commit.
 - Delete duplicate code paths. When a new shape replaces an old one, the
   old one goes in the same change.
 - No "deprecated" markings yet. Pre-1.0 there is no deprecation; there is
-  only "the right shape" and "the wrong shape."
+  only the right shape and the wrong shape.
 
 After 1.0, the rules invert: deprecation will be slow and deliberate, and
 backward compatibility will be maintained religiously. Anything left in the

--- a/book/src/getting-started/first-connection.md
+++ b/book/src/getting-started/first-connection.md
@@ -1,40 +1,62 @@
-# First connection: hello, hub
+# First Connection
 
-Install `tela`, `telad`, and `telahubd` before starting (see [Installation](installation.md)). The steps below walk through a minimal three-machine setup: one hub, one agent, one client, ending at a working SSH connection.
+This walkthrough takes a minimal three-machine setup, one hub, one agent,
+one client, from nothing to a working SSH connection. Install `tela`,
+`telad`, and `telahubd` before starting (see [Installation](installation.md)).
 
-For the full CLI reference including all flags and configuration options, see [Appendix A: CLI reference](../guide/reference.md).
+For the full CLI reference including all flags and configuration options,
+see [Appendix A: CLI Reference](../guide/reference.md).
 
-## The scenario
+## The Scenario
 
 Picture two machines that cannot reach each other directly:
 
-- **`web01`** is a Linux server sitting on a private network -- a home lab, a cloud VM behind NAT, a machine at a co-location facility, anything that has no publicly accessible inbound port. The name `web01` is just a label we give the machine inside Tela; it can be any string you choose. This is the machine you want to reach. It runs `telad`, the agent daemon.
-- **Your laptop** is wherever you are. It runs `tela`, the client. It also cannot accept inbound connections -- it is behind a home router or a corporate firewall.
+- **`web01`** is a Linux server sitting on a private network: a home lab, a
+  cloud VM behind NAT, a machine at a co-location facility, anything that
+  has no publicly accessible inbound port. The name `web01` is just a label
+  we give the machine inside Tela; it can be any string you choose. This is
+  the machine you want to reach. It runs `telad`, the agent daemon.
+- **Your laptop** is wherever you are. It runs `tela`, the client. It also
+  cannot accept inbound connections; it is behind a home router or a
+  corporate firewall.
 
-Because neither machine accepts inbound connections, they cannot talk to each other directly. The hub solves this.
+Because neither machine accepts inbound connections, they cannot talk to
+each other directly. The hub solves this.
 
-- **`hub.example.com`** is a small server with a public IP address. It does not need to be powerful -- it only brokers connections, it never decrypts tunnel traffic. It runs `telahubd`.
+- **`hub.example.com`** is a small server with a public IP address. It does
+  not need to be powerful, because it only brokers connections and never
+  decrypts tunnel traffic. It runs `telahubd`.
 
-Both `web01` and your laptop connect *outbound* to the hub. The hub pairs them together and starts relaying WireGuard packets between them. Once the WireGuard tunnel is up, your laptop can reach any port on `web01` as if the two machines were on the same network.
+Both `web01` and your laptop connect *outbound* to the hub. The hub pairs
+them together and starts relaying WireGuard packets between them. Once the
+WireGuard tunnel is up, your laptop can reach the exposed ports on `web01`
+as if the two machines were on the same network.
 
-When the walkthrough is done, your laptop will have a local port that reaches `web01`:
+When the walkthrough is done, your laptop will have a local port that
+reaches `web01`:
 
 ```
 Services available:
   localhost:22    → SSH
 ```
 
-The port shown is what `tela` bound on your machine. Use that port whenever you connect to `web01`.
+The client binds each service on `127.0.0.1` at the service's own port when
+that port is free locally. If it is taken, the client picks a fallback port
+(the service port plus 10000, then plus 10001, and so on) and shows the
+port it actually bound. Whatever the output shows is the port to use.
 
-## The three binaries, one on each machine
+## The Three Binaries, One on Each Machine
 
-- `telahubd` on `hub.example.com` -- the broker. Needs a public IP. Nothing sensitive passes through it in plaintext.
-- `telad` on `web01` -- the agent. Registers the machine with the hub and exposes its ports through the tunnel.
-- `tela` on your laptop -- the client. Connects to the hub, retrieves the tunnel to `web01`, and binds local addresses for each exposed port.
+- `telahubd` on `hub.example.com`: the broker. Needs a public IP. Nothing
+  sensitive passes through it in plaintext.
+- `telad` on `web01`: the agent. Registers the machine with the hub and
+  exposes its ports through the tunnel.
+- `tela` on your laptop: the client. Connects to the hub, sets up the
+  tunnel to `web01`, and binds local addresses for each exposed port.
 
 Nothing has to be open inbound on `web01` or your laptop.
 
-## Step 1: Start the hub
+## Step 1: Start the Hub
 
 On `hub.example.com`:
 
@@ -42,24 +64,25 @@ On `hub.example.com`:
 telahubd -port 8080
 ```
 
-`telahubd` listens on port 8080 (HTTP+WebSocket) and 41820 (UDP relay) in this
-example. The default is port 80, which requires elevated privileges on Linux;
-using a non-privileged port avoids that. Use a real config file with TLS for
-anything past a quick test. See
-[Run a hub on the public internet](../howto/hub.md) for the production
+`telahubd` listens on port 8080 (HTTP and WebSocket) and 41820 (UDP relay)
+in this example. The default is port 80, which requires elevated privileges
+on Linux; using a non-privileged port avoids that. Use a real config file
+with TLS for anything past a quick test. See
+[Run a Hub on the Public Internet](../howto/hub.md) for the production
 walkthrough.
 
-On first start the hub auto-generates an **owner token** and prints it. Save it
-somewhere; you will need it for everything below.
+On first start the hub auto-generates an **owner token** and prints it.
+Save it somewhere; you will need it for everything below.
 
-The owner token is the highest-privilege credential on the hub -- treat it like
-a root password. This walkthrough uses it directly for both the agent and the
-client for simplicity. In a real deployment you would create separate
-lower-privilege tokens for each: one for the agent (register permission) and one
-per user (connect permission). See [Run a hub on the public
-internet](../howto/hub.md) for the production pattern.
+The owner token is the highest-privilege credential on the hub. Treat it
+like a root password. This walkthrough uses it directly for both the agent
+and the client for simplicity. In a real deployment you would create
+separate lower-privilege tokens for each: one for the agent (register
+permission) and one per user (connect permission). See
+[Run a Hub on the Public Internet](../howto/hub.md) for the production
+pattern.
 
-## Step 2: Start the agent on web01
+## Step 2: Start the Agent on web01
 
 On `web01`:
 
@@ -71,7 +94,7 @@ This registers `web01` with the hub and tells the hub that the agent will
 expose TCP port 22. After a moment, the hub's `/api/status` endpoint should
 list `web01` as a registered machine.
 
-## Step 3: Connect from your laptop
+## Step 3: Connect from Your Laptop
 
 On your laptop:
 
@@ -80,7 +103,7 @@ tela connect -hub wss://hub.example.com:8080 -machine web01 -token <owner-token>
 ```
 
 The client opens a WireGuard tunnel through the hub to `web01` and binds
-SSH on a deterministic loopback address. The output shows the address:
+SSH on a local port. The output shows the address:
 
 ```
 Services available:
@@ -97,10 +120,12 @@ In another terminal, use the port from the output:
 ssh -p 22 user@localhost
 ```
 
-You're now SSH'd into `web01` through an end-to-end encrypted WireGuard
-tunnel that the hub never decrypted.
+You are now logged into `web01` through an end-to-end encrypted WireGuard
+tunnel that the hub never decrypted. If your laptop already runs its own
+SSH server on port 22, the output in step 3 will have shown a fallback
+port such as `localhost:10022`; use that instead.
 
-## What just happened
+## What Just Happened
 
 ```mermaid
 sequenceDiagram
@@ -118,15 +143,16 @@ sequenceDiagram
 ```
 
 The hub paired the two sides and started forwarding WireGuard packets. It
-cannot read those packets -- WireGuard's encryption is between the laptop
+cannot read those packets. WireGuard's encryption is between the laptop
 and `web01`, with keys neither side ever sent to the hub.
 
-## Where to go next
+## Where to Go Next
 
-- [Run a hub on the public internet](../howto/hub.md) for the real
+- [Run a Hub on the Public Internet](../howto/hub.md) for the real
   production setup with TLS, auth, and a service manager
-- [Run an agent](../howto/telad.md) for the agent's full deployment story
-- [Run Tela as an OS service](../howto/services.md) to survive reboots without manual restarts
-- [Self-update and release channels](../howto/channels.md) once you have
+- [Run an Agent](../howto/telad.md) for the agent's full deployment story
+- [Run Tela as an OS Service](../howto/services.md) to survive reboots
+  without manual restarts
+- [Self-Update and Release Channels](../howto/channels.md) once you have
   more than one box
-- [TelaVisor desktop app](../guide/telavisor.md) for a GUI alternative
+- [TelaVisor Desktop App](../guide/telavisor.md) for a GUI alternative

--- a/book/src/getting-started/installation.md
+++ b/book/src/getting-started/installation.md
@@ -1,7 +1,8 @@
 # Installation
 
-Tela ships through three release channels (`dev`, `beta`, `stable`). Once
-any one binary is installed, every subsequent update is one command:
+Tela ships through three release channels (`dev`, `beta`, `stable`). Only
+the first download is manual. Once any one binary is installed, every
+subsequent update is one command:
 
 ```bash
 tela update
@@ -9,17 +10,17 @@ telad update
 telahubd update
 ```
 
-The bootstrap step is the only one that needs a manual download. Pick whichever
-channel you want to follow.
+Pick whichever channel you want to follow. The examples below use `stable`;
+substitute `beta` or `dev` to follow a faster channel.
 
 ## Linux / macOS
 
 Pull the latest binary from a channel manifest:
 
 ```bash
-# Replace 'dev' with 'beta' or 'stable' as desired.
+# Replace 'stable' with 'beta' or 'dev' as desired.
 # Replace 'tela-linux-amd64' with the binary you want.
-curl -fsSL https://github.com/paulmooreparks/tela/releases/download/channels/dev.json \
+curl -fsSL https://github.com/paulmooreparks/tela/releases/download/channels/stable.json \
   | python3 -c 'import json,sys; m=json.load(sys.stdin); print(m["downloadBase"]+"tela-linux-amd64")' \
   | xargs curl -fLO
 
@@ -34,61 +35,62 @@ For `telad` and `telahubd`, repeat with the matching binary name.
 From PowerShell:
 
 ```powershell
-$m = Invoke-RestMethod https://github.com/paulmooreparks/tela/releases/download/channels/dev.json
+$m = Invoke-RestMethod https://github.com/paulmooreparks/tela/releases/download/channels/stable.json
 Invoke-WebRequest ($m.downloadBase + 'tela-windows-amd64.exe') -OutFile C:\Users\$env:USERNAME\bin\tela.exe
 ```
 
 Make sure `C:\Users\<you>\bin` is on your `PATH`.
 
-## TelaVisor (desktop GUI)
+## TelaVisor (Desktop GUI)
 
 For Windows, download the NSIS installer from any release page or directly
 from the channel manifest:
 
 ```powershell
-$m = Invoke-RestMethod https://github.com/paulmooreparks/tela/releases/download/channels/dev.json
+$m = Invoke-RestMethod https://github.com/paulmooreparks/tela/releases/download/channels/stable.json
 Invoke-WebRequest ($m.downloadBase + 'telavisor-windows-amd64-setup.exe') -OutFile TelaVisor-Setup.exe
 .\TelaVisor-Setup.exe
 ```
 
-For Linux, the channel manifest also contains `.deb`, `.rpm`, and a bare
-binary. For macOS, a `.tar.gz` of the `.app` bundle.
+For Linux, the channel manifest also lists `.deb` and `.rpm` packages and a
+bare binary. For macOS, a `.tar.gz` of the `.app` bundle.
 
 ## Channels
 
-| Channel | What it is | Tag form |
+| Channel | What It Is | Tag Form |
 |---------|------------|----------|
-| `dev`   | Latest unstable build, every commit to main | `v0.8.0-dev.42` |
-| `beta`  | Promoted dev build ready for wider exposure | `v0.8.0-beta.3` |
-| `stable`| Promoted beta build, the conservative line | `v0.8.0`, `v0.6.1` |
+| `dev`   | Latest unstable build, every commit to main | `v0.16.0-dev.15` |
+| `beta`  | Promoted dev build ready for wider exposure | `v0.16.0-beta.1` |
+| `stable`| Promoted beta build, the conservative line | `v0.16.0`, `v0.15.0` |
 
-The model is documented in [Release process](../ops/release-process.md).
+The model is documented in [Release Process](../ops/release-process.md).
 
-## Verifying downloads
+## Verifying Downloads
 
-Every download Tela does internally is SHA-256-verified against the channel
-manifest before being installed. If you want to verify a manual download by
+Every download Tela performs internally is SHA-256-verified against the
+channel manifest before being installed. To verify a manual download by
 hand, every release also publishes a `SHA256SUMS.txt` asset:
 
 ```bash
-curl -fLO https://github.com/paulmooreparks/tela/releases/download/v0.8.0-dev.8/SHA256SUMS.txt
+curl -fLO https://github.com/paulmooreparks/tela/releases/download/v0.16.0/SHA256SUMS.txt
 sha256sum -c SHA256SUMS.txt --ignore-missing
 ```
 
-## Next steps after downloading
+## Next Steps After Downloading
 
-Downloading the binary is the first step, not the last. What to do next depends on which binary you installed:
+Downloading the binary is the first step, not the last. What to do next
+depends on which binary you installed:
 
-| Binary | Next step |
+| Binary | Next Step |
 |--------|-----------|
-| `telahubd` | Follow [Run a hub on the public internet](../howto/hub.md). The walkthrough covers picking a deployment model (Caddy, nginx, Apache, Cloudflare Tunnel, or direct), installing the OS service, bootstrapping the owner token, and configuring the reverse proxy. |
-| `telad` | Follow [Run an agent](../howto/telad.md) to register a machine with a hub. |
-| `tela` client | Follow [First connection](./first-connection.md) to pair with a hub and open your first tunnel. |
+| `telahubd` | Follow [Run a Hub on the Public Internet](../howto/hub.md). The walkthrough covers picking a deployment model (Caddy, nginx, Apache, Cloudflare Tunnel, or direct), installing the OS service, bootstrapping the owner token, and configuring the reverse proxy. |
+| `telad` | Follow [Run an Agent](../howto/telad.md) to register a machine with a hub. |
+| `tela` client | Follow [First Connection](./first-connection.md) to pair with a hub and open your first tunnel. |
 | TelaVisor | Launch the app after install; it walks you through pairing on first run. |
 
-## After bootstrapping
+## After Bootstrapping
 
-Every Tela binary has a `update` subcommand that follows the configured
+Every Tela binary has an `update` subcommand that follows the configured
 channel. Once you have one of them installed, you no longer need to think
 about manual downloads:
 
@@ -111,5 +113,5 @@ the `update` subcommand: `sudo telahubd update -channel beta`. Any valid
 channel name works (dev, beta, stable, or a custom channel you have
 configured).
 
-For the full picture see the [Self-update and release channels](../howto/channels.md)
-how-to.
+For the full picture see the
+[Self-Update and Release Channels](../howto/channels.md) how-to.

--- a/book/src/getting-started/what-tela-is.md
+++ b/book/src/getting-started/what-tela-is.md
@@ -1,8 +1,10 @@
-# What Tela is
+# What Tela Is
 
-As mentioned in the introduction, Tela is a connectivity fabric. The basic operational unit in Tela is a *group*: one hub and all the agents connected to it. A collection of groups is a *fleet*.
+Tela is a connectivity fabric. The basic operational unit in Tela is a
+*group*: one hub and all the agents connected to it. A collection of groups
+is a *fleet*.
 
-## What it solves
+## What It Solves
 
 The classic remote-access problem looks like this. You have a machine
 somewhere: a workstation, a server, a Supervisory Control and Data
@@ -16,7 +18,7 @@ a kernel-mode VPN that requires admin rights to install.
 
 Most existing solutions force a tradeoff:
 
-| Solution | The tax |
+| Solution | The Tax |
 |----------|---------|
 | Traditional VPN | Admin to install on the client, inbound firewall rules on the server, often a kernel driver. |
 | SSH port forwarding | Requires SSH access to a publicly reachable jump host. |
@@ -27,12 +29,12 @@ Most existing solutions force a tradeoff:
 Tela takes the security guarantees of WireGuard and removes the deployment
 friction.
 
-## What makes Tela different
+## What Makes Tela Different
 
 A handful of properties define the design and run through every chapter of
 this book.
 
-### Outbound-only on both ends
+### Outbound-Only on Both Ends
 
 The agent and the client both make outbound connections to the hub.
 Neither needs an inbound firewall rule, port forwarding, dynamic Domain
@@ -40,7 +42,7 @@ Name System (DNS), or a static internet protocol (IP) address. The hub is
 the only component that needs a public address, and it only needs one
 inbound TCP port.
 
-### No kernel driver, no admin rights
+### No Kernel Driver, No Admin Rights
 
 Tela runs WireGuard entirely in userspace through gVisor's network stack.
 There is no TUN device, no kernel module, and no Administrator or root
@@ -48,33 +50,33 @@ requirement on either the agent or the client. This is the property that
 lets Tela work on a managed corporate laptop where you cannot install a
 VPN, and on a locked-down server where you cannot load drivers.
 
-### The hub is a blind relay
+### The Hub Is a Blind Relay
 
 All encryption is end to end between the agent and the client. The hub
 forwards opaque WireGuard ciphertext and cannot read session contents. A
 compromised hub leaks metadata, not data.
 
-### Any TCP service
+### Any TCP Service
 
 Tela tunnels arbitrary TCP. SSH, RDP, HTTP, PostgreSQL, SMB, Virtual
 Network Computing (VNC), or anything else that runs over TCP travels
 through the same tunnel without the hub having to understand the protocol.
 
-### Three transports, automatic fallback
+### Three Transports, Automatic Fallback
 
 The fabric tries direct peer-to-peer first, falls back to a User Datagram
 Protocol (UDP) relay through the hub, and falls back again to a WebSocket
 relay over Transport Layer Security (TLS). Whichever transport is active,
 the WireGuard payload is the same and the hub still cannot decrypt it.
 
-### One binary per role, no runtime dependencies
+### One Binary per Role, No Runtime Dependencies
 
 `tela`, `telad`, and `telahubd` are each a single executable. There is no
 installer, no package to register with the operating system unless you
 choose to run them as services, and no shared library to deploy alongside
 them.
 
-## What grows on top of the fabric
+## What Grows on Top of the Fabric
 
 Connectivity is the substrate. Everything else in this book is something
 the project has built on top of it, in the same repository, with the same
@@ -87,7 +89,7 @@ release process.
 - **Remote administration** of agents and hubs through the same wire as
   data traffic, so you do not need shell access to the host running an
   agent or a hub to manage it.
-- **File sharing** through a sandboxed directory on each agent, with
+- **File sharing** through sandboxed directories on each agent, with
   upload, download, rename, move, and delete operations available from the
   command line, the desktop client, or a Web Distributed Authoring and
   Versioning (WebDAV) mount.
@@ -96,29 +98,29 @@ release process.
   routing one tunnel port to several local services, a bridge-mode agent
   for fronting services on other LAN-reachable machines, outbound
   dependency rerouting for service-to-service calls, and the hub itself as
-  a relay gateway for opaque WireGuard ciphertext between a client and an
-  agent. They share one rule: forward without inspecting beyond what the
-  layer requires. The 1.0 roadmap extends the family with a multi-hop
-  relay gateway that bridges sessions across more than one hub.
+  a relay gateway for opaque WireGuard ciphertext, including relaying
+  between hubs. They share one rule: forward without inspecting beyond
+  what the layer requires.
 - **TelaVisor**, a desktop graphical interface that wraps the client and
   exposes the management features without requiring terminal access.
-- **Self-update through release channels** (dev, beta, stable) with signed
-  manifests, so every binary can update itself in place without an external
-  package manager.
-- **A hub directory protocol** that lets a portal list and discover hubs.
+- **Self-update through release channels** (dev, beta, stable) with
+  hash-verified manifests, so every binary can update itself in place
+  without an external package manager.
+- **A hub directory protocol** that lets a portal list and discover hubs,
+  and a standalone portal binary (`telaportal`) that implements it.
 
 These features are not bolted on. They share the protocol, the access
 model, the configuration system, and the release pipeline of the fabric
 itself.
 
-## What it is not
+## What It Is Not
 
 The word *fabric* invites projection, so a few explicit non-goals are worth
 naming up front.
 
 - **Not a mesh VPN.** There is no overlay network with auto-discovery and
   no agent-to-agent routing as a first-class feature. You connect to one
-  machine at a time. See *A note on the word fabric* below.
+  machine at a time. See *A Note on the Word Fabric* below.
 - **Not a multi-tenant SaaS.** You run the hub yourself. A portal can
   aggregate multiple hubs, but each hub still runs under its own operator's
   control.
@@ -128,12 +130,12 @@ naming up front.
 - **Not a replacement for SSH.** It is a way to *get* SSH (or RDP, or
   PostgreSQL) onto your laptop without configuring port forwarding or VPNs.
 
-The [Topology and addressing](../howto/networking.md#topology-and-addressing)
+The [Topology and Addressing](../howto/networking.md#topology-and-addressing)
 section in the Networking chapter answers specific questions about IP
 addressing, clash avoidance, discoverability, ICMP, agent-to-agent routing,
 and session limits.
 
-## Why three binaries
+## Why Three Binaries
 
 The split is deliberate.
 
@@ -156,7 +158,7 @@ address. They have different lifecycles, different threat models, and
 different update cadences. Bundling them would force shared concerns where
 there are none.
 
-## A note on the word *fabric*
+## A Note on the Word *Fabric*
 
 Tela is a fabric in the leaf-spine sense, not a mesh in the Tailscale
 sense. The hub is the spine. The agents and clients are the leaves. Most
@@ -174,5 +176,5 @@ art that justifies it.
 
 ---
 
-For the architectural details, see [Why a connectivity fabric](../architecture/design.md).
+For the architectural details, see [Why a Connectivity Fabric](../architecture/design.md).
 For installation, see [Installation](installation.md).

--- a/book/src/glossary.md
+++ b/book/src/glossary.md
@@ -2,18 +2,18 @@
 
 ## Agent
 
-A running instance of `telad` that registers one or more machines with a hub and
-forwards TCP connections from clients to local services. An agent initiates an
-outbound WebSocket connection to the hub and keeps it open; no inbound port is
-needed on the agent's host.
+A running instance of `telad` that registers one or more machines with a
+hub and forwards TCP connections from clients to local services. An agent
+initiates an outbound WebSocket connection to the hub and keeps it open; no
+inbound port is needed on the agent's host.
 
 Two deployment patterns:
 
-- **Endpoint agent**: `telad` runs on the same host as the services it exposes.
-  Each machine entry points to `127.0.0.1`.
-- **Gateway agent** (bridge): `telad` runs on a separate host that can reach
-  internal targets. Each machine entry points to a different IP on the local
-  network, letting one agent represent many machines.
+- **Endpoint agent**: `telad` runs on the same host as the services it
+  exposes. Each machine entry points to `127.0.0.1`.
+- **Gateway agent** (bridge): `telad` runs on a separate host that can
+  reach internal targets. Each machine entry points to a different IP on
+  the local network, letting one agent represent many machines.
 
 See also: [Machine](#machine), [Hub](#hub).
 
@@ -21,7 +21,8 @@ See also: [Machine](#machine), [Hub](#hub).
 
 ## Channel
 
-The release track a Tela binary follows for self-updates. Three channels exist:
+The release track a Tela binary follows for self-updates. Three channels
+exist:
 
 | Channel | Description |
 |---------|-------------|
@@ -29,58 +30,65 @@ The release track a Tela binary follows for self-updates. Three channels exist:
 | `beta` | Promoted from `dev` on demand. Stabilized builds for early adopters. |
 | `stable` | Promoted from `beta`. Recommended for production. |
 
-Each binary has its own channel setting. The `tela` client and TelaVisor share
-the setting in `credentials.yaml` (`update.channel`). `telad` and `telahubd`
-each have it in their own YAML config.
+Each binary has its own channel setting. The `tela` client and TelaVisor
+share the setting in `credentials.yaml` (`update.channel`). `telad` and
+`telahubd` each have it in their own YAML config. Operators can also define
+custom channels served from their own infrastructure.
 
-See [Release process](../ops/release-process.md).
-
----
-
-## Connect permission
-
-A machine permission that allows a token to open a client session (`tela connect`)
-to a specific machine. Multiple tokens may hold connect permission on the same
-machine. Owner and admin role tokens implicitly have connect access to all
-machines without an explicit grant.
-
-See also: [Machine permission](#machine-permission), [Role](#role).
+See [Release Process](ops/release-process.md).
 
 ---
 
-## Credential store
+## Connect Permission
 
-A per-user file (`credentials.yaml`) that stores hub tokens so you do not need
-to pass `-token` on every command. Written by `tela login`; read automatically
-by `tela` and TelaVisor. Stored at:
+A machine permission that allows a token to open a client session
+(`tela connect`) to a specific machine. Multiple tokens may hold connect
+permission on the same machine, and a connect grant can optionally be
+narrowed to specific named services. Owner and admin role tokens implicitly
+have connect access to all machines without an explicit grant.
+
+See also: [Machine Permission](#machine-permission), [Role](#role).
+
+---
+
+## Credential Store
+
+A per-user file (`credentials.yaml`) that stores hub tokens so you do not
+need to pass `-token` on every command. Written by `tela login`; read
+automatically by `tela` and TelaVisor. Stored at:
 
 - Windows: `%APPDATA%\tela\credentials.yaml`
 - Linux/macOS: `~/.tela/credentials.yaml`
 
-Token lookup order: `-token` flag > `TELA_TOKEN` environment variable >
-credential store (user, then system).
+A system-level store (`/etc/tela/credentials.yaml` on Unix,
+`%ProgramData%\Tela\credentials.yaml` on Windows) serves `telad` running as
+an OS service.
+
+See also: [Token](#token).
 
 ---
 
 ## Fabric
 
 The interconnection layer that lets endpoints reach each other without each
-endpoint knowing the topology. Tela is a fabric in the leaf-spine sense: the
-hub is the spine, agents and clients are the leaves, and most traffic travels
-client to hub to agent. Direct peer-to-peer connections are negotiated when
-the network allows, but they are an optimization rather than the default path.
+endpoint knowing the topology. Tela is a fabric in the leaf-spine sense:
+the hub is the spine, agents and clients are the leaves, and most traffic
+travels client to hub to agent. Direct peer-to-peer connections are
+negotiated when the network allows, but they are an optimization rather
+than the default path.
 
 Tela is not a routed mesh in the Tailscale, Nebula, or ZeroTier sense.
 
 ---
 
-## File share
+## File Share
 
-An optional feature of `telad` that exposes a sandboxed directory on the
-agent host for file transfer over the WireGuard tunnel. Disabled by default.
-Configured per machine under the `shares:` list in `telad.yaml`.
+An optional feature of `telad` that exposes one or more sandboxed
+directories on the agent host for file transfer over the WireGuard tunnel.
+Disabled by default. Configured per machine under the `shares:` list in
+`telad.yaml`.
 
-See [File sharing](../guide/file-sharing.md).
+See [File Sharing](guide/file-sharing.md).
 
 ---
 
@@ -114,34 +122,35 @@ See also: [Hub](#hub), [Fleet](#fleet).
 
 A running instance of `telahubd`. The hub is the coordination point for the
 fabric: it accepts WebSocket connections from agents and clients, relays
-encrypted WireGuard traffic between them, enforces access control, and serves
-the web console and admin API.
+encrypted WireGuard traffic between them, enforces access control, and
+serves the web console and admin API.
 
 The hub never decrypts tunnel payloads. WireGuard encryption is end-to-end
 between agent and client; the hub sees only ciphertext.
 
-See also: [Agent](#agent), [Zero-knowledge relay](#zero-knowledge-relay).
+See also: [Agent](#agent), [Zero-Knowledge Relay](#zero-knowledge-relay).
 
 ---
 
-## Hub alias
+## Hub Alias
 
-A short name mapped to a hub WebSocket URL in `hubs.yaml` (for local fallback)
-or via a portal remote (for network-resolved lookup). Aliases let you write
-`-hub owlsnest` instead of `-hub wss://tela.awansaya.net`. Alias lookup is
-case-sensitive.
+A short name mapped to a hub WebSocket URL in `hubs.yaml` (for local
+fallback) or via a portal remote (for network-resolved lookup). Aliases let
+you write `-hub work` instead of `-hub wss://hub.example.com`. Alias lookup
+is case-sensitive.
 
-See [Configuration](../guide/configuration.md).
+See [Appendix B: Configuration File Reference](guide/configuration.md).
 
 ---
 
 ## Identity
 
 The human-readable name attached to a token (for example, `alice`,
-`prod-web01-agent`, `ci-bot`). Identity names appear in the hub console, CLI
-output, and access listings. The name has no security function; the token value
-is the credential. You can rename an identity with `tela admin access rename`
-without affecting the underlying token or permissions.
+`prod-web01-agent`, `ci-bot`). Identity names appear in the hub console,
+CLI output, and access listings. The name has no security function; the
+token value is the credential. You can rename an identity with
+`tela admin access rename` without affecting the underlying token or
+permissions.
 
 See also: [Token](#token).
 
@@ -150,83 +159,91 @@ See also: [Token](#token).
 ## Machine
 
 A logical endpoint registered by an agent with a hub. A machine has a name
-(the ID used in `-machine` flags and access grants), an optional display name,
-and a list of exposed services. One `telad` process can register multiple
-machines. A machine is what operators connect to; it is not necessarily a
-physical host.
+(the ID used in `-machine` flags and access grants), an optional display
+name, and a list of exposed services. One `telad` process can register
+multiple machines. A machine is what operators connect to; it is not
+necessarily a physical host.
 
 See also: [Service](#service), [Agent](#agent).
 
 ---
 
-## Machine permission
+## Machine Permission
 
 A per-machine authorization entry that controls what a token can do on a
 specific machine. Three permissions exist:
 
-| Permission | What it allows |
+| Permission | What It Allows |
 |-----------|---------------|
-| `register` | Register an agent for this machine. Only one token may hold this per machine. |
+| `register` | Register an agent for this machine. One token holds this per machine. |
 | `connect` | Open a client session to this machine. Multiple tokens may hold this. |
-| `manage` | Send management commands (config, logs, restart) to this machine's agent. Multiple tokens may hold this. |
+| `manage` | Send management commands (config, logs, restart, update) to this machine's agent. Multiple tokens may hold this. |
 
-Permissions are granted with `tela admin access grant` and can use the wildcard
-`*` to apply to all machines. Owner and admin role tokens bypass all permission
+Permissions are granted with `tela admin access grant`. A wildcard machine
+ID of `*` applies connect and manage to all machines; register is always
+granted per machine. Owner and admin role tokens bypass all permission
 checks.
 
-See [Access model](../architecture/access-model.md).
+See [Appendix C: Access Model](architecture/access-model.md).
 
 ---
 
-## Manage permission
+## Manage Permission
 
 A machine permission that allows a token to send management commands to a
-machine's agent through the hub: read and write config, stream logs, restart
-the agent. Owner and admin role tokens have implicit manage access to all
-machines.
+machine's agent through the hub: read and write config, fetch logs, restart
+the agent, trigger self-update. Owner and admin role tokens have implicit
+manage access to all machines.
 
-See also: [Machine permission](#machine-permission).
+See also: [Machine Permission](#machine-permission).
 
 ---
 
-## Open mode
+## Open Mode
 
 The state the hub operates in when no tokens are configured. In open mode,
-every API call is permitted without authentication. The hub auto-generates an
-owner token on first startup specifically to prevent accidental open mode. Open
-mode requires deliberate configuration (removing all tokens from the config).
+every API call is permitted without authentication. The hub auto-generates
+an owner token on first startup specifically to prevent accidental open
+mode. Open mode requires deliberate configuration (removing all tokens from
+the config), and the hub logs a warning when running in it.
 
 ---
 
-## Pair code
+## Pair Code
 
-A short-lived, single-use code generated by the hub (`tela admin pair-code`)
-that lets a new agent or client authenticate without a pre-shared token. When
-the pair code is used, the hub issues a permanent token and saves it. Pair codes
-expire; their default lifetime is configurable.
+A short-lived, single-use code generated by the hub
+(`tela admin pair-code`) that lets a new agent or client authenticate
+without a pre-shared token. When the pair code is redeemed, the hub issues
+a permanent token and the redeeming side stores it. Codes expire after 10
+minutes by default; the generating administrator can set any expiry up to
+7 days.
 
-See [Hub administration](admin.md).
+See [Credentials and Pairing](guide/credentials.md).
 
 ---
 
 ## Portal
 
-A web service that maintains a directory of hubs. The `tela` client can resolve
-hub aliases through a portal using `tela remote add`. The portal protocol is a
-documented wire contract; Awan Saya is the reference implementation.
+A web service that maintains a directory of hubs, usually with a dashboard
+and identity layered on top. The `tela` client resolves hub aliases through
+a portal registered with `tela remote add`. The portal protocol is a
+documented wire contract; `telaportal` is Tela's own single-user
+implementation, and Awan Saya is the multi-organization reference
+implementation.
 
-See [Portal protocol](portal-protocol.md).
+See [Hub Directories and Portals](guide/directories.md) and
+[Appendix D: Portal Protocol](architecture/portal-protocol.md).
 
 ---
 
-## Register permission
+## Register Permission
 
-A machine permission that allows a token to register an agent for a specific
-machine. Only one token may hold the register permission per machine at a time.
-If a second token tries to register the same machine name with a different
-credential, the hub rejects it.
+A machine permission that allows a token to register an agent for a
+specific machine. One token holds the register permission per machine at a
+time; granting it to another identity replaces the previous holder. Unlike
+connect and manage, register does not cascade from the wildcard `*` entry.
 
-See also: [Machine permission](#machine-permission).
+See also: [Machine Permission](#machine-permission).
 
 ---
 
@@ -234,26 +251,27 @@ See also: [Machine permission](#machine-permission).
 
 A label on a token that controls hub-level API access. Four roles exist:
 
-| Role | Hub-level access | Machine-level access |
+| Role | Hub-Level Access | Machine-Level Access |
 |------|-----------------|---------------------|
 | `owner` | Full access including owner management | Implicit access to all machines |
 | `admin` | Full access except owner-only operations | Implicit access to all machines |
 | `user` | No admin API access | Only what machine permissions explicitly grant |
 | `viewer` | Read-only: `/api/status`, `/api/history` | None |
 
-The default role when none is specified is `user`. Roles are set at token
-creation time with the `-role` flag.
+The default role when none is specified is `user`. Owner and admin can be
+set at creation time with the `-role` flag; viewer is assigned by changing
+an existing identity's role.
 
-See [Access model](../architecture/access-model.md).
+See [Appendix C: Access Model](architecture/access-model.md).
 
 ---
 
 ## Service
 
 A TCP port exposed by a machine. A service has a port number, an optional
-name (for example, `SSH`, `Postgres`), and an optional protocol label.
-When a client connects to a machine, the tunnel maps each service port to a
-local address on the client's loopback interface.
+name (for example, `SSH`, `postgres`), and an optional protocol label. When
+a client connects to a machine, the tunnel maps each service port to a
+local port on the client's loopback interface.
 
 See also: [Machine](#machine).
 
@@ -263,20 +281,21 @@ See also: [Machine](#machine).
 
 A single client connection to a machine. Each session gets a /24 subnet on
 the `10.77.0.0/16` range: the agent side is `10.77.{idx}.1` and the client
-side is `10.77.{idx}.2`. Session index is monotonically incrementing per
-machine, up to 254 concurrent sessions.
+side is `10.77.{idx}.2`. These addresses exist only inside the userspace
+network stack. The session index is monotonically incrementing per machine,
+up to 254 concurrent sessions.
 
 ---
 
 ## TelaVisor
 
-The desktop graphical user interface (GUI) for Tela. Built with Wails v2 (Go
-backend, vanilla JavaScript frontend). Provides hub browsing, machine listing,
-connection management, agent management, and hub administration in a native
-window. Available on Windows; macOS and Linux builds require building from
-source.
+The desktop graphical user interface (GUI) for Tela. Built with Wails v2
+(Go backend, vanilla JavaScript frontend). Provides connection management,
+profiles, a file browser, and full hub, agent, and access administration in
+a native window. Released builds are published for Windows (installer),
+Linux (`.deb`, `.rpm`, and bare binary), and macOS (`.app` bundle).
 
-See [TelaVisor](telavisor.md).
+See [TelaVisor](guide/telavisor.md).
 
 ---
 
@@ -287,48 +306,53 @@ authentication credential for a hub. Tokens are shown in full only once, at
 creation or rotation time. The hub stores the full value for comparison;
 the admin API returns only an 8-character preview afterward.
 
-Token lookup order for CLI commands: `-token` flag > `TELA_TOKEN` environment
-variable > credential store.
+Token lookup order for CLI commands: `-token` flag, then the `TELA_TOKEN`
+environment variable, then the credential store.
 
-See also: [Identity](#identity), [Role](#role), [Credential store](#credential-store).
+See also: [Identity](#identity), [Role](#role),
+[Credential Store](#credential-store).
 
 ---
 
-## UDP relay
+## UDP Relay
 
-The fallback transport for WireGuard traffic when a direct peer-to-peer path
-cannot be negotiated. The hub listens on a UDP port (default 41820) and relays
-WireGuard packets between agent and client. If UDP is blocked, `tela` falls
-back automatically to WebSocket relay.
+The middle transport tier for WireGuard traffic. The hub listens on a UDP
+port (default 41820) and relays WireGuard packets between agent and client.
+Faster than the WebSocket relay; used when a direct peer-to-peer path
+cannot be negotiated but UDP to the hub is open. If UDP is blocked, the
+fabric falls back automatically to the WebSocket relay.
 
-See also: [WebSocket relay](#websocket-relay).
+See also: [WebSocket Relay](#websocket-relay).
 
 ---
 
 ## Upstream
 
-A named hub alias stored in a `telad` config, enabling `telad` to register the
-same machines with more than one hub. Upstreams let one agent be reachable
-through multiple independent hubs without running multiple `telad` processes.
+A TCP forwarding rule inside `telad` that intercepts outbound dependency
+calls from services on the agent machine and routes them to a configurable
+target. The service connects to a local port (`localhost:5432`); `telad`
+listens there and forwards to wherever the dependency actually lives.
+Declared per machine under `upstreams:` in `telad.yaml`.
 
-See [Upstreams](upstreams.md).
-
----
-
-## WebSocket relay
-
-The primary transport for WireGuard traffic. The hub relays encrypted WireGuard
-packets between agent and client over the same persistent WebSocket connection
-used for signaling. Works through HTTP proxies and corporate firewalls that
-block UDP. Slower than UDP relay for high-throughput workloads.
-
-See also: [UDP relay](#udp-relay).
+See [Upstreams](guide/upstreams.md).
 
 ---
 
-## Zero-knowledge relay
+## WebSocket Relay
 
-The property that the hub relays WireGuard-encrypted traffic without being able
-to decrypt it. WireGuard keys are held only by agents and clients. The hub sees
-ciphertext. This means a compromised hub cannot read tunnel payloads, only
-disrupt connectivity.
+The always-available transport for WireGuard traffic. The hub relays
+encrypted WireGuard packets between agent and client over the same
+persistent WebSocket connection used for signaling. Works through HTTP
+proxies and corporate firewalls that block UDP. Slower than the UDP relay
+for high-throughput workloads.
+
+See also: [UDP Relay](#udp-relay).
+
+---
+
+## Zero-Knowledge Relay
+
+The property that the hub relays WireGuard-encrypted traffic without being
+able to decrypt it. WireGuard keys are held only by agents and clients. The
+hub sees ciphertext. This means a compromised hub cannot read tunnel
+payloads, only disrupt connectivity.

--- a/book/src/guide/admin.md
+++ b/book/src/guide/admin.md
@@ -1,10 +1,15 @@
-# Hub administration
+# Hub Administration
 
-The `tela admin` subcommand manages a hub's tokens, access permissions, agent lifecycle, and portal registrations from the command line. All operations require a token with owner or admin role. Changes take effect immediately and persist to the hub's configuration file. No hub restart is needed.
+The `tela admin` subcommand manages a hub's tokens, access permissions,
+agent lifecycle, and portal registrations from the command line. All
+operations require a token with owner or admin role. Changes take effect
+immediately and persist to the hub's configuration file. No hub restart is
+needed.
 
 ## Authentication
 
-Every `tela admin` command requires a hub URL and an owner or admin token. User-role tokens are rejected. The owner token is printed once when you run `telahubd user bootstrap` and is never displayed again.
+Every `tela admin` command requires a hub URL and an owner or admin token.
+User-role tokens are rejected.
 
 ```bash
 tela admin tokens list -hub wss://hub.example.com -token <owner-token>
@@ -15,9 +20,10 @@ If the token is omitted, `tela` resolves it in this order:
 1. `-token` flag
 2. `TELA_OWNER_TOKEN` environment variable
 3. `TELA_TOKEN` environment variable
-4. Credential store -- the token stored by `tela login` for the hub URL
+4. Credential store: the token stored by `tela login` for the hub URL
 
-In practice, you log in once and omit the token flag on every subsequent command:
+In practice, you log in once and omit the token flag on every subsequent
+command:
 
 ```bash
 tela login wss://hub.example.com
@@ -26,19 +32,33 @@ tela login wss://hub.example.com
 tela admin tokens list -hub wss://hub.example.com
 ```
 
-The `-hub` flag accepts a short name if you have configured remotes, but the full URL is always accepted.
+The `-hub` flag accepts a short name if you have configured remotes, but
+the full URL is always accepted.
 
 ## Concepts
 
-A hub's authorization state has two parts: identities (tokens) and permissions.
+A hub's authorization state has two parts: identities (tokens) and
+permissions.
 
-An **identity** is a named token. It has a role: `owner`, `admin`, or `user` (the default). Owner and admin tokens bypass all machine permission checks. User tokens are subject to per-machine access control. A `viewer` role exists but is reserved for the hub's auto-generated console token; it cannot be assigned when creating tokens.
+An **identity** is a named token. It has a role: `owner`, `admin`, or
+`user` (the default). Owner and admin tokens bypass all machine permission
+checks. User tokens are subject to per-machine access control. A `viewer`
+role also exists for read-only console access; it cannot be chosen when
+creating a token, but an existing identity can be changed to it (see
+[Roles](#roles) below).
 
-**Machine permissions** determine what a user-role token can do on a specific machine: `connect`, `register`, and `manage`. These are stored as entries in the access control list. A wildcard machine ID of `*` applies the permission to all machines.
+**Machine permissions** determine what a user-role token can do on a
+specific machine: `connect`, `register`, and `manage`. These are stored as
+entries in the access control list. A wildcard machine ID of `*` applies
+connect and manage permissions to all machines, including ones registered
+later; register permission is always granted per machine.
 
-The `tokens` resource manages identities. The `access` resource manages the permissions attached to those identities. The `rotate` command replaces the secret value of a token without changing its identity or permissions.
+The `tokens` resource manages identities. The `access` resource manages the
+permissions attached to those identities. The `rotate` command replaces the
+secret value of a token without changing its identity or permissions.
 
-For the formal definition of roles and permissions, see [Appendix C: Access model](../architecture/access-model.md).
+For the formal definition of roles and permissions, see
+[Appendix C: Access Model](../architecture/access-model.md).
 
 ## Tokens
 
@@ -55,9 +75,11 @@ tela admin tokens add <id> -hub wss://hub.example.com -role admin
 tela admin tokens remove <id> -hub wss://hub.example.com
 ```
 
-`tokens add` prints the token value once and never again. Copy it before closing the terminal. If you lose it, use `rotate` to issue a new one.
+`tokens add` prints the token value once and never again. Copy it before
+closing the terminal. If you lose it, use `rotate` to issue a new one.
 
-`tokens remove` deletes the identity and all its machine permissions. There is no soft delete or recovery.
+`tokens remove` deletes the identity and all its machine permissions. There
+is no soft delete or recovery.
 
 The default role for a new identity is `user`.
 
@@ -68,11 +90,18 @@ The default role for a new identity is `user`.
 | `owner` | Full access to all hub operations, including owner-only actions |
 | `admin` | Full access to all hub operations except owner-only actions |
 | `user` | Access to machines governed by per-machine permissions |
-| `viewer` | Read-only access to machines they have connect permission on |
+| `viewer` | Read-only access to hub status and history |
+
+`tokens add` accepts `-role owner` and `-role admin`; new identities cannot
+be created as viewers. To make an identity a viewer, create it as a user
+and change its role afterward (in TelaVisor, the *Change role...* action on
+the Access tab). The hub refuses to demote its only owner; promote another
+identity to owner first.
 
 ## Access
 
-The `access` resource provides a unified view of identities and their per-machine permissions.
+The `access` resource provides a unified view of identities and their
+per-machine permissions.
 
 ```bash
 # List all identities and their permissions
@@ -81,8 +110,11 @@ tela admin access -hub wss://hub.example.com
 # Grant permissions to an identity on a machine
 tela admin access grant <id> <machine> <perms> -hub wss://hub.example.com
 
-# Grant permissions on all machines
+# Grant connect on all machines
 tela admin access grant <id> '*' connect -hub wss://hub.example.com
+
+# Restrict a connect grant to specific services
+tela admin access grant <id> <machine> connect -services ssh,postgres -hub wss://hub.example.com
 
 # Revoke all permissions for an identity on a machine
 tela admin access revoke <id> <machine> -hub wss://hub.example.com
@@ -94,31 +126,44 @@ tela admin access rename <id> <new-id> -hub wss://hub.example.com
 tela admin access remove <id> -hub wss://hub.example.com
 ```
 
-Permissions are specified as a comma-separated list. Valid values are `connect`, `register`, and `manage`.
+Permissions are specified as a comma-separated list. Valid values are
+`connect`, `register`, and `manage`.
 
 ```bash
 # Grant connect and register on a specific machine
 tela admin access grant alice barn connect,register -hub wss://hub.example.com
 ```
 
-A `*` machine ID grants the permission on every machine, including ones registered after the grant is made.
+A `*` machine ID grants connect and manage on every machine, including ones
+registered after the grant is made.
+
+The `-services` flag narrows a connect grant to a named subset of the
+machine's services. It is valid only when `connect` is among the granted
+permissions, and it requires a hub recent enough to support per-service
+access control; against an older hub the command refuses rather than
+silently granting broader access.
 
 ## Rotate
 
-`rotate` generates a new secret value for an existing identity without changing its name, role, or permissions. Use it to revoke a leaked token while keeping the identity intact.
+`rotate` generates a new secret value for an existing identity without
+changing its name, role, or permissions. Use it to revoke a leaked token
+while keeping the identity intact.
 
 ```bash
 tela admin rotate <id> -hub wss://hub.example.com
 ```
 
-The new token value is printed once. The old token stops working immediately.
+The new token value is printed once. The old token stops working
+immediately.
 
-## Pair codes
+## Pair Codes
 
-A pairing code is a short, single-use code that lets you onboard a user or agent without distributing a raw token. The recipient redeems the code to receive a permanent token.
+A pairing code is a short, single-use code that lets you onboard a user or
+agent without distributing a raw token. The recipient redeems the code to
+receive a permanent token.
 
 ```bash
-# Generate a connect code for machine barn (default expiry 24h)
+# Generate a connect code for machine barn (default expiry 10 minutes)
 tela admin pair-code barn -hub wss://hub.example.com
 
 # Set a custom expiry
@@ -131,23 +176,28 @@ tela admin pair-code barn -hub wss://hub.example.com -type register
 tela admin pair-code barn -hub wss://hub.example.com -machines '*'
 ```
 
-The output includes the code and the redemption command to give to the recipient:
+The output includes the code and the redemption command to give to the
+recipient:
 
 ```
 Generated pairing code: ABCD-1234
-Expires: 2026-04-15T10:30:00Z
+Expires: 2026-07-15T10:30:00Z
 
 Client pairing command:
   tela pair -hub wss://hub.example.com -code ABCD-1234
 ```
 
-Codes expire between 10 minutes and 7 days after generation. The `-expires` flag accepts Go duration syntax: `10m`, `24h`, `7d`.
+The default expiry is 10 minutes; the maximum is 7 days. The `-expires`
+flag accepts Go duration syntax plus a `d` suffix for days: `10m`, `24h`,
+`7d`.
 
-For how users and agents redeem codes, see [Credentials and pairing](credentials.md).
+For how users and agents redeem codes, see
+[Credentials and Pairing](credentials.md).
 
 ## Agent
 
-The `agent` resource lets you inspect and manage remote `telad` instances through the hub, without a direct connection to the agent machine.
+The `agent` resource lets you inspect and manage remote `telad` instances
+through the hub, without a direct connection to the agent machine.
 
 ```bash
 # List registered agents
@@ -168,7 +218,6 @@ tela admin agent restart -machine barn -hub wss://hub.example.com
 
 # Trigger a self-update
 tela admin agent update -machine barn -hub wss://hub.example.com
-tela admin agent update -machine barn -hub wss://hub.example.com -version v0.9.1
 
 # Show the agent's current release channel
 tela admin agent channel -machine barn -hub wss://hub.example.com
@@ -177,7 +226,9 @@ tela admin agent channel -machine barn -hub wss://hub.example.com
 tela admin agent channel -machine barn -hub wss://hub.example.com set stable
 ```
 
-Agent management commands are forwarded through the hub to the agent and wait for a response. If the agent is offline or does not respond within 30 seconds, the command returns an error.
+Agent management commands are forwarded through the hub to the agent and
+wait for a response. If the agent is offline or does not respond within 30
+seconds, the command returns an error.
 
 ## Hub
 
@@ -196,7 +247,6 @@ tela admin hub restart -hub wss://hub.example.com
 
 # Trigger a self-update
 tela admin hub update -hub wss://hub.example.com
-tela admin hub update -hub wss://hub.example.com -version v0.9.1
 
 # Show the current release channel
 tela admin hub channel -hub wss://hub.example.com
@@ -207,7 +257,8 @@ tela admin hub channel set stable -hub wss://hub.example.com
 
 ## Portals
 
-Portals are external registries that list hubs for discovery. The `portals` resource manages which portals a hub is registered with.
+Portals are external registries that list hubs for discovery. The `portals`
+resource manages which portals a hub is registered with.
 
 ```bash
 # List registered portals
@@ -220,11 +271,13 @@ tela admin portals add <name> -portal-url <url> -hub wss://hub.example.com
 tela admin portals remove <name> -hub wss://hub.example.com
 ```
 
-Portal changes take effect immediately. The hub begins syncing with a newly added portal without a restart.
+Portal changes take effect immediately. The hub begins syncing with a newly
+added portal without a restart.
 
-## Flag placement
+## Flag Placement
 
-All `tela admin` subcommands accept flags after positional arguments. Both of these are equivalent:
+All `tela admin` subcommands accept flags after positional arguments. Both
+of these are equivalent:
 
 ```bash
 tela admin tokens add alice -hub wss://hub.example.com -role admin

--- a/book/src/guide/configuration.md
+++ b/book/src/guide/configuration.md
@@ -1,4 +1,4 @@
-# Appendix B: Configuration file reference
+# Appendix B: Configuration File Reference
 
 The complete configuration file reference for the three Tela binaries plus the portal hub directory format. Use this appendix as a lookup. The body of the book explains what each setting does and when to change it in narrative form; this appendix lists every key in every config file with its default, its valid values, and a one-line description for the moments when you want to look something up rather than read about it.
 

--- a/book/src/guide/credentials.md
+++ b/book/src/guide/credentials.md
@@ -1,24 +1,31 @@
-# Credentials and pairing
+# Credentials and Pairing
 
-Tela stores hub tokens in a local credential file so you do not need to pass a `-token` flag on every command. This chapter explains how credentials are stored, how to add and remove them, and how one-time pairing codes let administrators onboard users and agents without distributing 64-character hex tokens by hand.
+Tela stores hub tokens in a local credential file so you do not need to
+pass a `-token` flag on every command. This chapter explains how
+credentials are stored, how to add and remove them, and how one-time
+pairing codes let administrators onboard users and agents without
+distributing 64-character hex tokens by hand.
 
-## The credential store
+## The Credential Store
 
 The credential store is a YAML file at:
 
 - **Linux / macOS:** `~/.tela/credentials.yaml`
 - **Windows:** `%APPDATA%\tela\credentials.yaml`
 
-It is written with 0600 permissions (owner read/write only). It maps hub URLs to tokens. When `tela` or `telad` needs a token for a hub and none is provided on the command line, it looks here first.
+It is written with 0600 permissions (owner read/write only). It maps hub
+URLs to tokens. When `tela` or `telad` needs a token for a hub and none is
+provided on the command line, it looks here first.
 
-`telad` running as an OS service uses a system-level credential store instead:
+`telad` running as an OS service uses a system-level credential store
+instead:
 
 - **Linux:** `/etc/tela/credentials.yaml`
 - **Windows:** `%ProgramData%\Tela\credentials.yaml`
 
 Writing to the system store requires administrator or root privileges.
 
-## Storing credentials
+## Storing Credentials
 
 ```bash
 tela login wss://hub.example.com
@@ -26,7 +33,9 @@ tela login wss://hub.example.com
 # Identity (press Enter to skip): alice
 ```
 
-`tela login` prompts for a token and an optional identity label, then stores both in the user credential store. Once stored, any `tela` command targeting that hub finds the token automatically.
+`tela login` prompts for a token and an optional identity label, then
+stores both in the user credential store. Once stored, any `tela` command
+targeting that hub finds the token automatically.
 
 For `telad` running as a service:
 
@@ -35,37 +44,50 @@ sudo telad login -hub wss://hub.example.com
 # Token: (paste token, press Enter)
 ```
 
-`telad login` requires elevated privileges because it writes to the system credential store.
+`telad login` requires elevated privileges because it writes to the system
+credential store.
 
-## Removing credentials
+## Removing Credentials
 
 ```bash
 tela logout wss://hub.example.com
 sudo telad logout -hub wss://hub.example.com
 ```
 
-## Pinning a hub's TLS certificate
+## Pinning a Hub's TLS Certificate
 
-Tokens prove that the bearer is allowed to talk to a hub. They do not prove that the connection is *actually reaching that hub* and not a rogue proxy in the middle. Tela addresses that with TLS certificate pinning: a per-hub fingerprint stored alongside the token, checked on every `tela connect`, refused on mismatch.
+Tokens prove that the bearer is allowed to talk to a hub. They do not prove
+that the connection is *actually reaching that hub* and not a rogue proxy
+in the middle. Tela addresses that with TLS certificate pinning: a per-hub
+fingerprint stored alongside the token, checked on every `tela connect`,
+refused on mismatch.
 
-The fingerprint is the SHA-256 hash of the hub's TLS leaf certificate's Subject Public Key Info (SPKI), formatted as `sha256:<lowercase hex>`. Pinning the SPKI rather than the whole certificate means certificate renewal with the same key does not break the pin. Key rotation does break the pin, which is the point: a key rotation is exactly the case where the operator should re-confirm the change.
+The fingerprint is the SHA-256 hash of the hub's TLS leaf certificate's
+Subject Public Key Info (SPKI), formatted as `sha256:<lowercase hex>`.
+Pinning the SPKI rather than the whole certificate means certificate
+renewal with the same key does not break the pin. Key rotation does break
+the pin, which is the point: a key rotation is exactly the case where the
+operator should re-confirm the change.
 
-### First connect (TOFU)
+### First Connect (TOFU)
 
-The first time `tela connect` succeeds against a hub with no pin configured, it logs the captured fingerprint and the exact command to enforce it next time:
+The first time `tela connect` succeeds against a hub with no pin
+configured, it logs the captured fingerprint and the exact command to
+enforce it next time:
 
 ```
 hub wss://hub.example.com presented certificate sha256:1a2b...3456 (no pin configured;
 run 'tela pin wss://hub.example.com sha256:1a2b...3456' to enforce it)
 ```
 
-If you want the connection refused on any future certificate change, copy the fingerprint and pin it:
+If you want the connection refused on any future certificate change, copy
+the fingerprint and pin it:
 
 ```bash
 tela pin wss://hub.example.com sha256:1a2b...3456
 ```
 
-### Inspect, change, or remove a pin
+### Inspect, Change, or Remove a Pin
 
 ```bash
 tela pin wss://hub.example.com                       # show the current pin
@@ -73,15 +95,17 @@ tela pin wss://hub.example.com sha256:newfingerprint # update (use after a delib
 tela pin wss://hub.example.com -clear                # remove (return to plain CA-chain trust)
 ```
 
-### Pinning at credential-creation time
+### Pinning at Credential-Creation Time
 
 ```bash
 tela login wss://hub.example.com -pin sha256:1a2b...3456
 ```
 
-Useful when the operator gives you both the token and the expected fingerprint up front (out-of-band, e.g. a chat message or a printed handout for an air-gapped onboarding).
+Useful when the operator gives you both the token and the expected
+fingerprint up front, out of band: a chat message, or a printed handout
+for an air-gapped onboarding.
 
-### What a pin mismatch looks like
+### What a Pin Mismatch Looks Like
 
 ```
 $ tela connect -hub wss://hub.example.com -machine prod-db
@@ -89,13 +113,19 @@ websocket dial failed: ... certpin: presented certificate does not match
 pinned fingerprint: got sha256:9999..., want sha256:1a2b...
 ```
 
-The connection is refused before any token, machine name, or other secret is sent. If this happens unexpectedly, do not update the pin until you have confirmed the change with the hub operator out-of-band.
+The connection is refused before any token, machine name, or other secret
+is sent. If this happens unexpectedly, do not update the pin until you have
+confirmed the change with the hub operator out of band.
 
-## Pairing codes
+## Pairing Codes
 
-A pairing code is a short, single-use code that a hub administrator generates for a user or agent. The recipient redeems it for a permanent token without ever seeing or handling the raw token value. Codes expire between 10 minutes and 7 days after generation.
+A pairing code is a short, single-use code that a hub administrator
+generates for a user or agent. The recipient redeems it for a permanent
+token without ever seeing or handling the raw token value. Codes expire
+after 10 minutes by default; the administrator can set any expiry up to
+7 days.
 
-### Generating a code (administrator)
+### Generating a Code (Administrator)
 
 ```bash
 # Generate a connect code for a user (grants connect access to machine barn)
@@ -111,25 +141,30 @@ tela admin pair-code barn -hub wss://hub.example.com -token <owner-token> -type 
 tela admin pair-code barn -hub wss://hub.example.com -token <owner-token> -machines '*'
 ```
 
-The command prints the code and the corresponding redemption command to give to the recipient:
+The command prints the code and the corresponding redemption command to
+give to the recipient:
 
 ```
 Generated pairing code: ABCD-1234
-Expires: 2026-04-15T10:30:00Z
+Expires: 2026-07-15T10:30:00Z
 
 Client pairing command:
   tela pair -hub wss://hub.example.com -code ABCD-1234
 ```
 
-Codes can also be generated from TelaVisor's Access tab, using the *Pair Code...* button in the toolbar, for administrators who prefer a graphical interface.
+Codes can also be generated from TelaVisor's Access tab, using the
+*Pair Code...* button in the toolbar, for administrators who prefer a
+graphical interface.
 
-### Redeeming a code (user)
+### Redeeming a Code (User)
 
 ```bash
 tela pair -hub wss://hub.example.com -code ABCD-1234
 ```
 
-`tela pair` contacts the hub, exchanges the code for a permanent token, and stores the token in the user credential store. The code is consumed on redemption and cannot be used again.
+`tela pair` contacts the hub, exchanges the code for a permanent token, and
+stores the token in the user credential store. The code is consumed on
+redemption and cannot be used again.
 
 After pairing, the user can connect without a `-token` flag:
 
@@ -137,12 +172,18 @@ After pairing, the user can connect without a `-token` flag:
 tela connect -hub wss://hub.example.com -machine barn
 ```
 
-### Redeeming a code (agent)
+### Redeeming a Code (Agent)
 
 ```bash
 sudo telad pair -hub wss://hub.example.com -code ABCD-1234
 ```
 
-`telad pair` stores the resulting token in the system credential store. The agent then connects to the hub without a token in its config file.
+`telad pair` stores the resulting token in the system credential store. The
+agent then connects to the hub without a token in its config file.
 
-For administrators who prefer a graphical interface and run `telad` on the same machine as TelaVisor (developer workstations, single-host setups), the Agents tab's *Redeem...* button opens a dialog that runs the same `telad pair` invocation under the hood. The button only handles the local case; agents on remote hosts must redeem on the host itself, since the resulting token has to land in that host's credential store.
+For administrators who prefer a graphical interface and run `telad` on the
+same machine as TelaVisor (developer workstations, single-host setups), the
+Agents tab's *Redeem...* button opens a dialog that runs the same
+`telad pair` invocation under the hood. The button only handles the local
+case; agents on remote hosts must redeem on the host itself, since the
+resulting token has to land in that host's credential store.

--- a/book/src/guide/directories.md
+++ b/book/src/guide/directories.md
@@ -1,4 +1,4 @@
-# Hub directories and portals
+# Hub Directories and Portals
 
 A single hub is enough for one team in one place. Real organizations end up
 with several: per environment, per customer, per region, per acquisition.
@@ -6,7 +6,7 @@ The fabric handles this with a small directory protocol that lets a client
 resolve hub names instead of memorizing URLs, and an optional portal layer
 that adds dashboards and visibility on top of the directory.
 
-## The directory protocol
+## The Directory Protocol
 
 Tela ships a hub directory protocol as part of the fabric, not as a separate
 product. Two endpoints define it:
@@ -20,9 +20,11 @@ product. Two endpoints define it:
   (URL), and optional metadata.
 
 That is the whole protocol. Anything that responds correctly on those two
-endpoints is a hub directory, regardless of what else it does.
+endpoints is a hub directory, regardless of what else it does. The full
+wire contract is specified in
+[Appendix D: Portal Protocol](../architecture/portal-protocol.md).
 
-## Adding a directory as a remote
+## Adding a Directory as a Remote
 
 On the client side, a hub directory is added as a **remote**:
 
@@ -40,11 +42,11 @@ tela connect -hub myhub -machine prod-web01
 
 The client does not change otherwise. The same `tela connect` command works
 whether the user typed a full URL or a name that resolved through a
-directory. A user's CLI can register more than one remote: a self-hosted
-directory for internal hubs, a managed directory for cross-organization or
-customer hubs, the same `tela` binary talking to both.
+directory. A client can register more than one remote: a self-hosted
+directory for internal hubs and a managed directory for cross-organization
+or customer hubs, with the same `tela` binary talking to both.
 
-## Listing a hub in a directory
+## Listing a Hub in a Directory
 
 On the hub side, a hub registers itself with a directory through the
 `telahubd portal` subcommand:
@@ -61,7 +63,7 @@ stores the association in the hub's configuration. From that point on, any
 client whose remote points at the same directory can find the hub by
 name.
 
-## What a portal adds on top
+## What a Portal Adds on Top
 
 The directory protocol is the floor. A **portal** is a directory plus
 whatever extras the operator wants to layer on. Typical additions:
@@ -86,22 +88,21 @@ and authorizes connections on its own, with its own tokens and its own
 access control list. The portal handles discovery, identity, and
 visibility, not trust delegation.
 
-## Two operating models
+## Three Ways to Run One
 
-Two paths to a working directory. Same protocol, different operating
-models.
+The protocol is the contract; where the server comes from is up to you.
 
-| Self-hosted directory | Managed directory |
-|-----------------------|-------------------|
-| You implement `/.well-known/tela` and `/api/hubs`, or run an existing portal you control | A vendor runs the directory and the dashboard for you |
-| Everything stays on your own infrastructure | Multi-hub visibility, personal API tokens, web console without operating the server |
-| Suitable when compliance or sovereignty rule out a hosted option | Suitable when fleet visibility and onboarding speed matter more than self-hosting |
-| Tela ships the protocol; you ship the server | **Awan Saya** is one such managed option, available on request |
+| Option | What It Is | When to Pick It |
+|--------|------------|-----------------|
+| **`telaportal`** | Tela's own standalone portal binary. Single-user, file-backed storage, zero external dependencies. Implements the full portal protocol. | You want name resolution and a personal dashboard for your own hubs without operating anything heavier than the hubs themselves. |
+| **Your own implementation** | Any service that answers `/.well-known/tela` and `/api/hubs` correctly. | You already have an internal service catalog or portal and want Tela hubs listed in it. |
+| **A managed portal** | A vendor-operated directory and dashboard. **Awan Saya** is one such option, available on request. | Fleet visibility, multi-organization access control, and onboarding speed matter more than self-hosting. |
 
 The CLI does not care which one a remote points at. The same
-`tela remote add` command and the same name-resolution path work for both.
+`tela remote add` command and the same name-resolution path work for all
+three.
 
-## When you need a directory at all
+## When You Need a Directory at All
 
 If you are running a single hub for personal use, you do not need a
 directory or a portal. The hub stands alone, the client connects to it by

--- a/book/src/guide/file-sharing.md
+++ b/book/src/guide/file-sharing.md
@@ -1,27 +1,35 @@
-# File sharing
+# File Sharing
 
-Tela file sharing lets authorized clients browse, download, upload, rename, move, and delete files on a remote machine through the same encrypted WireGuard tunnel that carries TCP service traffic. No SSH, no SFTP, and no separate credentials are required beyond a Tela token with connect permission on the machine.
+Tela file sharing lets authorized clients browse, download, upload, rename,
+move, and delete files on a remote machine through the same encrypted
+WireGuard tunnel that carries TCP service traffic. No SSH, no SFTP, and no
+separate credentials are required beyond a Tela token with connect
+permission on the machine.
 
-File sharing is off by default and must be explicitly enabled per machine by the agent operator.
+File sharing is off by default and must be explicitly enabled per machine
+by the agent operator.
 
-## Enabling file sharing
+## Enabling File Sharing
 
-Add a `shares` list to a machine in `telad.yaml`. Each entry defines one shared directory with its own name and access controls.
+Add a `shares` list to a machine in `telad.yaml`. Each entry defines one
+shared directory with its own name and access controls.
 
 ```yaml
 machines:
   - name: barn
-    ports: [22, 3389]
+    services:
+      - port: 22
+        name: SSH
     shares:
       - name: files
         path: /home/shared
 ```
 
-`telad` creates each share directory on startup if it does not exist. Each path must be absolute. `telad` refuses to start if any share path is a system directory (`/`, `/etc`, `C:\Windows`, and similar).
+`telad` creates each share directory on startup if it does not exist. Each
+path must be absolute. `telad` refuses to start if any share path is a
+system directory (`/`, `/etc`, `C:\Windows`, and similar).
 
-If you are upgrading from an older configuration that used `fileShare:` (singular), that key is still accepted and is synthesized as a share named `legacy`. It will be removed at 1.0. Migrate to the `shares` list.
-
-### Configuration reference
+### Configuration Reference
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
@@ -34,7 +42,7 @@ If you are upgrading from an older configuration that used `fileShare:` (singula
 | `allowedExtensions` | []string | `[]` | Whitelist of file extensions. Empty means all extensions are allowed, subject to `blockedExtensions`. |
 | `blockedExtensions` | []string | see below | Blacklist of file extensions. By default blocks `.exe`, `.bat`, `.cmd`, `.ps1`, and `.sh`. Applied after `allowedExtensions`. |
 
-### A read-only log share
+### A Read-Only Log Share
 
 ```yaml
 shares:
@@ -43,7 +51,7 @@ shares:
     writable: false
 ```
 
-### A writable staging area
+### A Writable Staging Area
 
 ```yaml
 shares:
@@ -56,7 +64,7 @@ shares:
     allowedExtensions: [".zip", ".tar.gz", ".yaml"]
 ```
 
-### Multiple shares on one machine
+### Multiple Shares on One Machine
 
 ```yaml
 shares:
@@ -72,7 +80,8 @@ shares:
 
 ## Access from the CLI
 
-The `tela files` subcommand provides operations on connected machines. An active tunnel must be established with `tela connect` first.
+The `tela files` subcommand provides operations on connected machines. An
+active tunnel must be established with `tela connect` first.
 
 ```bash
 # List files in a share
@@ -103,9 +112,12 @@ tela files mv -machine barn -share files logs/jan.txt archive/2026/jan.txt
 tela files info -machine barn
 ```
 
-## Mounting as a local drive
+## Mounting as a Local Drive
 
-`tela mount` starts a WebDAV server that exposes Tela file shares as a local drive. Each connected machine with file sharing enabled appears as a top-level folder, with each share as a subfolder inside it (`/machine/share/path`).
+`tela mount` starts a WebDAV server that exposes Tela file shares as a
+local drive. Each connected machine with file sharing enabled appears as a
+top-level folder, with each share as a subfolder inside it
+(`/machine/share/path`).
 
 ```bash
 # Windows: mount as drive letter T:
@@ -115,20 +127,39 @@ tela mount -mount T:
 tela mount -mount ~/tela
 ```
 
-No kernel drivers or third-party software are required. On Windows this uses the built-in WebDAV client (WebClient service). On macOS and Linux it uses the OS WebDAV mount support.
+No kernel drivers or third-party software are required. On Windows this
+uses the built-in WebDAV client (WebClient service). On macOS and Linux it
+uses the OS WebDAV mount support.
 
 ## Access from TelaVisor
 
-The Files tab in TelaVisor provides a graphical file browser for machines with file sharing enabled. It shows file name, size, and modification time. You can download files via the system file dialog, upload files (when `writable: true`), delete files (when `allowDelete: true`), navigate subdirectories with breadcrumb navigation, and drag and drop files to upload.
+The Files tab in TelaVisor provides a graphical file browser for machines
+with file sharing enabled. It shows file name, size, and modification time.
+You can download files via the system file dialog, upload files (when
+`writable: true`), delete files (when `allowDelete: true`), navigate
+subdirectories with breadcrumb navigation, and drag and drop files to
+upload.
 
-The machine list in the Connections view shows a file-sharing indicator when a machine advertises the capability, distinguishing between read-only and read-write configurations.
+The machine list in the Connections view shows a file-sharing indicator
+when a machine advertises the capability, distinguishing between read-only
+and read-write configurations.
 
 ## Security
 
-File sharing uses the existing `connect` permission. A token that can connect to a machine can use file sharing on that machine. No separate permission is required.
+File sharing uses the existing `connect` permission. A token that can
+connect to a machine can use file sharing on that machine. No separate
+permission is required.
 
-All file operations are sandboxed to the declared directory. Path traversal is rejected at the protocol level: the server validates every client-supplied path using `filepath.Rel` to confirm it cannot escape the sandbox, and uses `os.Lstat` to reject symlinks. No file operation is delegated to OS-level permissions alone.
+All file operations are sandboxed to the declared directory. Path traversal
+is rejected at the protocol level: the server validates every
+client-supplied path using `filepath.Rel` to confirm it cannot escape the
+sandbox, and uses `os.Lstat` to reject symlinks. No file operation is
+delegated to OS-level permissions alone.
 
-The shared directory is never accessible without an active authenticated Tela session. File contents travel inside the WireGuard tunnel as ciphertext. The hub sees nothing different from any other tunnel traffic.
+The shared directory is never accessible without an active authenticated
+Tela session. File contents travel inside the WireGuard tunnel as
+ciphertext. The hub sees nothing different from any other tunnel traffic.
 
-For the design rationale behind these choices, see [File sharing](../architecture/file-sharing.md) in the Design Rationale section.
+For the design rationale behind these choices, see
+[File Sharing](../architecture/file-sharing.md) in the Design Rationale
+section.

--- a/book/src/guide/gateway.md
+++ b/book/src/guide/gateway.md
@@ -1,20 +1,28 @@
-# The path gateway
+# The Path Gateway
 
-The path gateway is a built-in HTTP reverse proxy inside `telad`. It exposes one tunnel port and routes incoming HTTP requests to different local services based on URL path prefix, eliminating the need for a separate nginx, Caddy, or Traefik instance for tunnel-internal routing.
+The path gateway is a built-in HTTP reverse proxy inside `telad`. It
+exposes one tunnel port and routes incoming HTTP requests to different
+local services based on URL path prefix, eliminating the need for a
+separate nginx, Caddy, or Traefik instance for tunnel-internal routing.
 
-## When to use a gateway
+## When to Use a Gateway
 
-Use a gateway when you have several HTTP services on one machine and want to reach all of them through a single tunnel port. Common examples:
+Use a gateway when you have several HTTP services on one machine and want
+to reach all of them through a single tunnel port. Common examples:
 
 - A web frontend, a REST API, and a metrics endpoint running on the same host
 - A multi-page web app with backend services on different ports
 - A development stack you want accessible through one URL
 
-You do not need a gateway when you have only one HTTP service (just expose it as a normal service), when your services use TCP rather than HTTP (expose them as normal TCP services), or when you already use a reverse proxy in front of your services and want to keep it as the edge.
+You do not need a gateway when you have only one HTTP service (just expose
+it as a normal service), when your services use TCP rather than HTTP
+(expose them as normal TCP services), or when you already use a reverse
+proxy in front of your services and want to keep it as the edge.
 
-## How it works
+## How It Works
 
-Without a gateway, a client connecting to a multi-service application gets one binding per service port:
+Without a gateway, a client connecting to a multi-service application gets
+one binding per service port:
 
 ```
 localhost:3000   → port 3000
@@ -22,7 +30,11 @@ localhost:4000   → port 4000
 localhost:4100   → port 4100
 ```
 
-The browser opens `http://localhost:3000` and calls the API on a different origin (`localhost:4000`). Same host, different port -- that is still a cross-origin request under browser CORS rules, which means either CORS headers on the API server, a hardcoded API URL in the UI code, or an extra proxy layer somewhere.
+The browser opens `http://localhost:3000` and calls the API on a different
+origin (`localhost:4000`). Same host, different port: that is still a
+cross-origin request under browser Cross-Origin Resource Sharing (CORS)
+rules, which means either CORS headers on the API server, a hardcoded API
+URL in the UI code, or an extra proxy layer somewhere.
 
 With a gateway, the client gets one binding:
 
@@ -30,14 +42,17 @@ With a gateway, the client gets one binding:
 localhost:8080   → HTTP
 ```
 
-The browser opens `http://localhost:8080/`. The UI calls `/api/users`. The gateway sees the `/api/` prefix and proxies the request to the local API service. Same origin. No CORS. No extra configuration.
+The browser opens `http://localhost:8080/`. The UI calls `/api/users`. The
+gateway sees the `/api/` prefix and proxies the request to the local API
+service. Same origin. No CORS. No extra configuration.
 
 ## Configuration
 
-Gateway configuration lives in `telad.yaml` under each machine, alongside the `services:` list:
+Gateway configuration lives in `telad.yaml` under each machine, alongside
+the `services:` list:
 
 ```yaml
-hub: wss://your-hub.example.com
+hub: wss://hub.example.com
 token: "<your-agent-token>"
 
 machines:
@@ -57,9 +72,13 @@ machines:
           target: 3000
 ```
 
-This declares one direct TCP service (PostgreSQL on port 5432, exposed through the tunnel as usual) and a gateway listening on port 8080 with three routes. The HTTP services on ports 3000, 4000, and 4100 are not in the `services:` list -- they are private to the machine and reachable only through the gateway. The tunnel exposes port 8080 and port 5432.
+This declares one direct TCP service (PostgreSQL on port 5432, exposed
+through the tunnel as usual) and a gateway listening on port 8080 with
+three routes. The HTTP services on ports 3000, 4000, and 4100 are not in
+the `services:` list; they are private to the machine and reachable only
+through the gateway. The tunnel exposes port 8080 and port 5432.
 
-### Field reference
+### Field Reference
 
 | Field | Required | Description |
 |-------|----------|-------------|
@@ -68,9 +87,11 @@ This declares one direct TCP service (PostgreSQL on port 5432, exposed through t
 | `routes[].path` | Yes | URL path prefix to match (e.g. `/api/`, `/admin/`, `/`). |
 | `routes[].target` | Yes | Local TCP port to proxy matched requests to. |
 
-### Route matching
+### Route Matching
 
-Routes are matched by longest path prefix first. The order in the YAML file does not matter; `telad` sorts them at startup. A route with `path: /` matches any request not claimed by a more specific route.
+Routes are matched by longest path prefix first. The order in the YAML file
+does not matter; `telad` sorts them at startup. A route with `path: /`
+matches any request not claimed by a more specific route.
 
 With these routes:
 
@@ -84,16 +105,19 @@ routes:
     target: 4000
 ```
 
-A request to `/api/v2/users` matches `/api/v2/` (target 4002). A request to `/api/health` matches `/api/` (target 4000). A request to `/about` matches `/` (target 3000).
+A request to `/api/v2/users` matches `/api/v2/` (target 4002). A request to
+`/api/health` matches `/api/` (target 4000). A request to `/about` matches
+`/` (target 3000).
 
-## Connecting through a gateway
+## Connecting Through a Gateway
 
-The gateway appears to clients as a service named `gateway`. Use it in a connection profile like any other service:
+The gateway appears to clients as a service named `gateway`. Use it in a
+connection profile like any other service:
 
 ```yaml
 # ~/.tela/profiles/barn.yaml
 connections:
-  - hub: wss://your-hub.example.com
+  - hub: wss://hub.example.com
     machine: barn
     services:
       - name: gateway
@@ -112,7 +136,8 @@ Services available:
   localhost:5432   → port 5432
 ```
 
-Port labels come from the well-known port table (22=SSH, 80/8080=HTTP, 3389=RDP, etc.). Ports not in the table show as `port N`.
+Port labels come from the well-known port table (22=SSH, 80/8080=HTTP,
+3389=RDP, and so on). Ports not in the table show as `port N`.
 
 If port 8080 conflicts with something local, override it:
 
@@ -122,9 +147,12 @@ services:
     local: 18080
 ```
 
-### Direct access alongside the gateway
+### Direct Access Alongside the Gateway
 
-You can expose a service both through the gateway (for browser access) and as a direct service (for tools like `curl` or Postman). Add it to the agent's `services:` list as well as the gateway routes, then include it in the profile:
+You can expose a service both through the gateway (for browser access) and
+as a direct service (for tools like `curl` or Postman). Add it to the
+agent's `services:` list as well as the gateway routes, then include it in
+the profile:
 
 ```yaml
 # telad.yaml
@@ -146,7 +174,7 @@ machines:
 ```yaml
 # profile
 connections:
-  - hub: wss://your-hub.example.com
+  - hub: wss://hub.example.com
     machine: barn
     services:
       - name: gateway
@@ -154,11 +182,14 @@ connections:
         local: 14000
 ```
 
-Now `http://localhost:8080/api/...` reaches the API through the gateway, and `http://localhost:14000/...` reaches it directly.
+Now `http://localhost:8080/api/...` reaches the API through the gateway,
+and `http://localhost:14000/...` reaches it directly.
 
-## Cross-environment use
+## Cross-Environment Use
 
-When you maintain the same application across several environments, each running its own `telad`, a profile can connect to multiple gateways simultaneously:
+When you maintain the same application across several environments, each
+running its own `telad`, a profile can connect to multiple gateways
+simultaneously:
 
 ```yaml
 connections:
@@ -174,10 +205,26 @@ connections:
         local: 18080
 ```
 
-When connecting to both environments simultaneously, use `local:` overrides to put them on different ports. Without an override, both gateways would try to bind `localhost:8080` and the second would fall back to `localhost:18080`. Making it explicit avoids relying on fallback behavior. The routing logic stays in each environment's `telad.yaml`, not in the client profile.
+When connecting to both environments simultaneously, use `local:` overrides
+to put them on different ports. Without an override, both gateways would
+try to bind `localhost:8080` and the second would fall back to
+`localhost:18080`. Making it explicit avoids relying on fallback behavior.
+The routing logic stays in each environment's `telad.yaml`, not in the
+client profile.
 
 ## Limitations
 
-The gateway does not terminate TLS (the WireGuard tunnel already provides end-to-end encryption). It does not authenticate users (that is the hub's token and ACL layer). It does not load-balance across instances. It does not proxy WebSocket connections -- if you need WebSocket access to a service, expose it as a separate service alongside the gateway. It is not a replacement for an internet-facing reverse proxy with TLS termination, rate limiting, or WAF rules.
+The gateway does not terminate TLS (the WireGuard tunnel already provides
+end-to-end encryption). It does not authenticate users (that is the hub's
+token and ACL layer). It does not load-balance across instances. It does
+not transform requests or responses beyond rewriting the `Host` header to
+the local target. It is not a replacement for an internet-facing reverse
+proxy with TLS termination, rate limiting, or WAF rules. If a service
+depends on long-lived WebSocket connections and misbehaves behind the
+gateway, expose it as a separate direct service alongside the gateway.
 
-For the design rationale and the relationship between the path gateway and the other gateway primitives in Tela, see [Gateways](../architecture/gateway.md) in the Design Rationale section. For a step-by-step setup walkthrough and troubleshooting, see [Set up a path-based gateway](../howto/gateway.md).
+For the design rationale and the relationship between the path gateway and
+the other gateway primitives in Tela, see
+[Gateways](../architecture/gateway.md) in the Design Rationale section. For
+a step-by-step setup walkthrough and troubleshooting, see
+[Set Up a Path-Based Gateway](../howto/gateway.md).

--- a/book/src/guide/hub-console.md
+++ b/book/src/guide/hub-console.md
@@ -1,32 +1,44 @@
-# Hub web console
+# Hub Web Console
 
-The hub ships with a built-in web console served at its HTTP address. Point a browser at `http://hub.example.com:PORT/` (or `https://` if TLS is configured) and the console loads automatically.
+The hub ships with a built-in web console served at its HTTP address. Point
+a browser at `http://hub.example.com:PORT/` (or `https://` if TLS is
+configured) and the console loads automatically.
 
-No separate installation is required. The console is embedded in the `telahubd` binary.
+No separate installation is required. The console is embedded in the
+`telahubd` binary.
 
 ## Sections
 
 ### Machines
 
-The Machines section lists every registered agent and its services. Each row shows the machine name, registered services (name and port), current status, and active session count.
+The Machines section lists every registered agent and its services. Each
+row shows the machine name, registered services (name and port), current
+status, and active session count.
 
 Status indicators:
 
 | Indicator | Meaning |
 |-----------|---------|
-| Green dot | Online -- agent connected within the last 30 seconds |
-| Yellow dot | Stale -- agent has not sent a keepalive recently |
+| Green dot | Online: agent connected within the last 30 seconds |
+| Yellow dot | Stale: agent has not sent a keepalive recently |
 | No dot | Offline |
 
-Click the **Refresh** button to reload from the hub. The "last updated" timestamp shows when data was last fetched.
+Click the **Refresh** button to reload from the hub. The "last updated"
+timestamp shows when data was last fetched.
 
 ### Recent Activity
 
-The Recent Activity section shows the last 200 connection events: sessions opened, sessions closed, and agent registrations. Each entry shows the timestamp, event type, machine name, and client address.
+The Recent Activity section shows the most recent connection events
+(sessions opened, sessions closed, agent registrations), up to the hub's
+in-memory history capacity of 100 events. Each entry shows the timestamp,
+event type, machine name, and client address. The history buffer is held in
+memory and resets when the hub restarts.
 
-### Pairing (admin only)
+### Pairing (Admin Only)
 
-Administrators see a Pairing section not visible to other users. It generates one-time pairing codes without requiring `tela admin pair-code` on the command line.
+The console shows a Pairing section when its session is authorized as owner
+or admin. It generates one-time pairing codes without requiring
+`tela admin pair-code` on the command line.
 
 Fields:
 
@@ -36,26 +48,43 @@ Fields:
 | Expiration | 10 minutes, 1 hour, 24 hours, 7 days | How long the code remains valid |
 | Machine scope | Machine ID or `*` | Which machine(s) the code grants access to |
 
-After clicking **Generate Code**, the console displays the short code and the redemption command to give to the recipient. The code is single-use and cannot be regenerated.
+After clicking **Generate Code**, the console displays the short code and
+the redemption command to give to the recipient. The code is single-use and
+cannot be regenerated.
 
 ### Download
 
-When a stable or beta release has been published to the GitHub Release channel, the Download section appears with direct links to the `tela` client binary for each supported platform and architecture.
+When a stable or beta release has been published, the Download section
+appears with direct links to the `tela` client binary for each supported
+platform and architecture.
 
 ### CLI Quick Reference
 
-A brief reminder of the most common `tela` commands, for operators sharing hub access with users who are not yet familiar with the client.
+A brief reminder of the most common `tela` commands, for operators sharing
+hub access with users who are not yet familiar with the client.
 
 ## Authentication
 
-The hub injects a viewer token into the console page at load time. This token has the `viewer` role and allows read-only access to the Machines and Recent Activity data without any login step.
+The hub injects a read-only viewer token into the console page at load
+time, so the Machines and Recent Activity data is visible without any login
+step. The viewer token grants no session or admin privileges.
 
-The Pairing section appears only when the browser presents a token with `owner` or `admin` role. You can authenticate at a higher level by appending `?token=<admin-token>` to the console URL.
+Administrative operations are not the console's job. To manage tokens,
+permissions, agents, or pairing at full fidelity, use `tela admin` from a
+terminal or TelaVisor's Infrastructure mode, both of which authenticate
+with your own owner or admin token. Passing a token in the URL query string
+is deprecated and should not be used; query strings leak into logs and
+browser history.
 
 ## Theme
 
-The console supports light, dark, and system-preference themes. The toggle is in the top navigation bar. The preference is stored in browser local storage.
+The console supports light, dark, and system-preference themes. The toggle
+is in the top navigation bar. The preference is stored in browser local
+storage.
 
-## When to use the console vs. the CLI
+## When to Use the Console vs. the CLI
 
-The console is convenient for checking machine status at a glance and for generating pairing codes without terminal access. For anything beyond those two tasks -- managing tokens, changing permissions, viewing agent configuration, or triggering updates -- use `tela admin` from a terminal.
+The console is convenient for checking machine status and recent activity
+at a glance from any browser, with zero setup. For management tasks
+(tokens, permissions, agent configuration, updates, pairing codes), use
+`tela admin` from a terminal or TelaVisor.

--- a/book/src/guide/profiles.md
+++ b/book/src/guide/profiles.md
@@ -1,10 +1,13 @@
-# Connection profiles
+# Connection Profiles
 
-A connection profile is a YAML file that describes one or more tunnels. Running `tela connect -profile <name>` opens all of them in parallel with a single command, each reconnecting independently on failure.
+A connection profile is a YAML file that describes one or more tunnels.
+Running `tela connect -profile <name>` opens all of them in parallel with a
+single command, each reconnecting independently on failure.
 
-Profiles live in `~/.tela/profiles/` (or `%APPDATA%\tela\profiles\` on Windows). Each file is named `<profile-name>.yaml`.
+Profiles live in `~/.tela/profiles/` (or `%APPDATA%\tela\profiles\` on
+Windows). Each file is named `<profile-name>.yaml`.
 
-## A minimal profile
+## A Minimal Profile
 
 ```yaml
 # ~/.tela/profiles/work.yaml
@@ -19,11 +22,14 @@ connections:
 tela connect -profile work
 ```
 
-This opens a tunnel to port 22 on `dev-server` and binds it to a deterministic loopback address. Use `tela status` to see the bound address.
+This opens a tunnel to port 22 on `dev-server` and binds it on
+`localhost:22`, or on a fallback port if 22 is taken locally. Use
+`tela status` to see the bound address.
 
-## Multiple connections
+## Multiple Connections
 
-A profile can open tunnels to any number of machines across any number of hubs simultaneously:
+A profile can open tunnels to any number of machines across any number of
+hubs simultaneously:
 
 ```yaml
 connections:
@@ -44,11 +50,15 @@ connections:
       - name: postgres
 ```
 
-Each connection gets its own deterministic loopback address. Services on different machines never share a local port.
+When two machines expose the same port, the first to bind gets the native
+port and the others land on fallback ports. To make the layout predictable,
+give each service an explicit `local:` port (see below).
 
-## Tokens and credentials
+## Tokens and Credentials
 
-If a token is stored in the credential store for a hub (via `tela login` or `tela pair`), the profile does not need to include it. The token is looked up automatically.
+If a token is stored in the credential store for a hub (via `tela login` or
+`tela pair`), the profile does not need to include it. The token is looked
+up automatically.
 
 To embed a token explicitly:
 
@@ -59,22 +69,25 @@ connections:
     token: ${MY_HUB_TOKEN}
 ```
 
-Profile YAML supports environment variable expansion with `${VAR}` syntax. This is useful for tokens in CI/CD environments where you do not want credentials in files on disk.
+Profile YAML supports environment variable expansion with `${VAR}` syntax.
+This is useful for tokens in CI/CD environments where you do not want
+credentials in files on disk.
 
-## Specifying services
+## Specifying Services
 
-Services can be identified by port number, by name, or with a local port override:
+Services can be identified by port number, by name, or with a local port
+override:
 
 ```yaml
 services:
-  # By port number -- connects remote port 22 to local port 22
+  # By port number: connects remote port 22 to local port 22
   - remote: 22
 
-  # By port number with a local override -- useful when 22 is taken locally
+  # By port number with a local override: useful when 22 is taken locally
   - remote: 22
     local: 2222
 
-  # By service name -- resolves the port from the hub's service registry
+  # By service name: resolves the port from the hub's service registry
   - name: postgres
 
   # By service name with a local port override
@@ -82,26 +95,20 @@ services:
     local: 13389
 ```
 
-When you specify `name: gateway` the gateway service is resolved the same way as any other named service.
+Each service binds a listener on `127.0.0.1` at its local port (which
+defaults to the remote port). If that port is already in use, the client
+falls back to the port plus 10000, then plus 10001, and so on, and prints
+the port it actually bound. A `local:` override makes the port explicit so
+you never depend on fallback behavior.
 
-## Pinning a loopback address
+A path gateway on the agent appears to clients as a service named
+`gateway` and is selected the same way as any other named service.
 
-By default each machine gets a deterministic loopback address derived from the hub URL and machine name. To fix a specific address instead:
+## Auto-Mounting File Shares
 
-```yaml
-connections:
-  - hub: wss://hub.example.com
-    machine: barn
-    address: 127.99.1.1
-    services:
-      - remote: 22
-```
-
-The address must be in the `127.0.0.0/8` range.
-
-## Auto-mounting file shares
-
-If machines in the profile have file sharing enabled, you can configure the profile to mount them as a local drive automatically when the profile connects:
+If machines in the profile have file sharing enabled, you can configure the
+profile to mount them as a local drive automatically when the profile
+connects:
 
 ```yaml
 connections:
@@ -116,22 +123,7 @@ mount:
   port: 18080      # WebDAV listen port (default 18080)
 ```
 
-## DNS name resolution
-
-The `dns` block configures the loopback prefix used by `tela dns hosts` for this profile:
-
-```yaml
-connections:
-  - hub: wss://hub.example.com
-    machine: barn
-
-dns:
-  loopback_prefix: "127.88"   # prefix for 'tela dns hosts' entries; does not affect port binding
-```
-
-See the [DNS names](#dns-names) section below for how to add machine names to your hosts file.
-
-## Managing profiles
+## Managing Profiles
 
 ```bash
 tela profile list               # list all profiles
@@ -140,15 +132,18 @@ tela profile create staging     # create a new empty profile at ~/.tela/profiles
 tela profile delete old-work    # delete a profile
 ```
 
-`tela profile create` writes a starter file with example comments. Edit it with any text editor.
+`tela profile create` writes a starter file with example comments. Edit it
+with any text editor.
 
-## DNS names
+## DNS Names
 
-`tela dns hosts` generates `/etc/hosts` entries for all machines in a profile, using their deterministic loopback addresses:
+`tela dns hosts` generates hosts-file entries for all machines in a
+profile. Each machine gets a stable loopback address derived from its hub
+URL and machine name, so the entries survive reconnects:
 
 ```bash
 tela dns hosts
-# Tela local names -- generated by 'tela dns hosts'
+# Tela local names, generated by 'tela dns hosts'
 # 127.88.12.34       barn.tela
 # 127.88.56.78       dev-server.tela
 ```
@@ -178,13 +173,32 @@ ssh user@barn.tela
 psql -h dev-server.tela -U postgres
 ```
 
-## Running a profile as an OS service
+Two profile fields tune the generated addresses. The `dns` block sets the
+loopback prefix used for all machines in the profile, and a per-connection
+`address:` field overrides the derived address for one machine:
 
-A profile can run as a persistent OS service that reconnects automatically after reboots and connection drops:
+```yaml
+connections:
+  - hub: wss://hub.example.com
+    machine: barn
+    address: 127.99.1.1      # fixed address for barn in 'tela dns hosts' output
+
+dns:
+  loopback_prefix: "127.88"  # prefix for derived addresses (default 127.88)
+```
+
+An `address:` override must be in the `127.0.0.0/8` range. Both fields
+affect only the hosts entries that `tela dns hosts` generates; they do not
+change the ports that `tela connect` binds.
+
+## Running a Profile as an OS Service
+
+A profile can run as a persistent OS service that reconnects automatically
+after reboots and connection drops:
 
 ```bash
 tela service install -config ~/.tela/profiles/work.yaml
 tela service start
 ```
 
-See [Run Tela as an OS service](../howto/services.md) for the full setup.
+See [Run Tela as an OS Service](../howto/services.md) for the full setup.

--- a/book/src/guide/reference.md
+++ b/book/src/guide/reference.md
@@ -1,4 +1,4 @@
-# Appendix A: CLI reference
+# Appendix A: CLI Reference
 
 Flags, subcommands, environment variables, and config schemas for `tela`,
 `telad`, and `telahubd`. For narrative explanations, see the User Guide and
@@ -30,8 +30,9 @@ tela connect -profile <name>
 | `-v` | | Verbose logging |
 
 When neither `-ports` nor `-services` is specified, all ports the agent
-advertises are forwarded. Each machine gets a deterministic loopback address
-at `localhost:PORT`; each service binds at its configured local port, or a fallback port if that is taken.
+advertises are forwarded. Each service binds on `127.0.0.1` at its
+configured local port (defaulting to the remote port), or at a fallback
+port (the port plus 10000, then plus 10001, and so on) if that is taken.
 
 ### `tela machines`
 
@@ -82,7 +83,7 @@ Remote hub management. Requires an owner or admin token.
 
 Token resolution order: `-token` flag > `TELA_OWNER_TOKEN` > `TELA_TOKEN` > credential store.
 
-**access** -- unified identity and per-machine permissions view
+**access**: unified identity and per-machine permissions view
 
 ```bash
 tela admin access [-hub <hub>] [-token <token>]
@@ -92,7 +93,7 @@ tela admin access rename <id> <new-id>
 tela admin access remove <id>
 ```
 
-**tokens** -- token identity CRUD
+**tokens**: token identity CRUD
 
 ```bash
 tela admin tokens list
@@ -101,7 +102,7 @@ tela admin tokens remove <id>
 tela admin rotate <id>                             # regenerate a token
 ```
 
-**portals** -- portal registrations on the hub
+**portals**: portal registrations on the hub
 
 ```bash
 tela admin portals list
@@ -109,7 +110,7 @@ tela admin portals add <name> -portal-url <url>
 tela admin portals remove <name>
 ```
 
-**pair-code** -- one-time onboarding codes
+**pair-code**: one-time onboarding codes
 
 ```bash
 tela admin pair-code <machine> [-type connect|register] [-expires <duration>] [-machines <list>]
@@ -121,7 +122,7 @@ tela admin pair-code <machine> [-type connect|register] [-expires <duration>] [-
 | `-expires` | `10m` | Duration: `10m`, `1h`, `24h`, `7d` |
 | `-machines` | `*` | Comma-separated machine IDs (connect type only) |
 
-**agent** -- remote management of `telad` through the hub
+**agent**: remote management of `telad` through the hub
 
 ```bash
 tela admin agent list
@@ -134,7 +135,7 @@ tela admin agent channel -machine <id>
 tela admin agent channel -machine <id> set <channel>    # dev, beta, stable, or a custom channel name
 ```
 
-**hub** -- lifecycle management of the hub itself
+**hub**: lifecycle management of the hub itself
 
 ```bash
 tela admin hub status
@@ -233,7 +234,7 @@ Config location when installed as a service:
 tela version
 ```
 
-### Connection profile schema
+### Connection Profile Schema
 
 Profiles define multiple hub/machine connections that launch in parallel with
 `tela connect -profile <name>`.
@@ -263,7 +264,7 @@ connections:
     machine: web01
     agentId: ""                       # stable agent UUID (populated lazily)
     token: ${WEB_TOKEN}               # ${VAR} expansion is supported
-    address: ""                       # override loopback address (must be in 127.0.0.0/8)
+    address: ""                       # per-machine address override for tela dns hosts (127.0.0.0/8)
     services:
       - remote: 22                    # forward by port number
         local: 2201                   # optional local port remap
@@ -293,7 +294,7 @@ connections:
 | `machine` | Yes | Machine name |
 | `agentId` | No | Stable agent UUID; populated lazily, do not set manually |
 | `token` | No | Auth token; `${VAR}` references are expanded from the environment |
-| `address` | No | Loopback address override (must be in `127.0.0.0/8`) |
+| `address` | No | Per-machine address override used by `tela dns hosts` (must be in `127.0.0.0/8`); does not affect connect bindings |
 | `services` | No | Port/service filter; omit to forward all ports |
 | `services[].remote` | * | Remote port number |
 | `services[].local` | No | Local port override (defaults to remote) |
@@ -301,7 +302,7 @@ connections:
 
 \* Each service entry needs either `remote` or `name`, not both.
 
-### Hub name resolution
+### Hub Name Resolution
 
 When `-hub` is a short name (not `ws://` or `wss://`), `tela` resolves it in order:
 
@@ -309,7 +310,7 @@ When `-hub` is a short name (not `ws://` or `wss://`), `tela` resolves it in ord
 2. Local `hubs.yaml` fallback.
 3. Error if unresolved.
 
-### Environment variables
+### Environment Variables
 
 | Variable | Description |
 |----------|-------------|
@@ -321,7 +322,7 @@ When `-hub` is a short name (not `ws://` or `wss://`), `tela` resolves it in ord
 | `TELA_MTU` | WireGuard tunnel MTU (default 1100) |
 | `TELA_MOUNT_PORT` | WebDAV listen port for `tela mount` (default 18080) |
 
-### Config and credential storage
+### Config and Credential Storage
 
 | File | Platform | Path |
 |------|----------|------|
@@ -361,7 +362,7 @@ to local services.
 | `-mtu <n>` | `TELAD_MTU` | `1100` | WireGuard tunnel MTU |
 | `-v` | | | Verbose logging |
 
-### Port spec format
+### Port Spec Format
 
 ```
 port[:name[:description]]
@@ -369,7 +370,7 @@ port[:name[:description]]
 
 Examples: `22`, `22:SSH`, `22:SSH:OpenSSH server`, `22:SSH,3389:RDP`
 
-### Config file (`telad.yaml`)
+### Config File (`telad.yaml`)
 
 ```yaml
 hub: wss://hub.example.com
@@ -416,7 +417,7 @@ machines:
 
 \* Either `ports` or `services` is required. If both are present, `services` takes precedence.
 
-### File share config
+### File Share Config
 
 ```yaml
 shares:
@@ -447,9 +448,8 @@ Each entry in `shares` is a named share. Clients navigate to a share by name bef
 | `allowedExtensions` | `[]` | Whitelist; empty means all allowed |
 | `blockedExtensions` | see above | Blacklist; applied after allowlist |
 
-The deprecated `fileShare:` (singular) key is accepted and synthesized as a share named `legacy`. It will be removed in 1.0.
 
-### Upstream config
+### Upstream Config
 
 ```yaml
 upstreams:
@@ -467,7 +467,7 @@ upstreams:
 | `target` | Yes | Address to forward to (`host:port`) |
 | `name` | No | Label for logging |
 
-### Gateway config
+### Gateway Config
 
 ```yaml
 gateway:
@@ -487,7 +487,7 @@ gateway:
 | `routes[].path` | Yes | URL path prefix; longest match wins |
 | `routes[].target` | Yes | Local port to proxy to |
 
-### `telad service` subcommands
+### `telad service` Subcommands
 
 | Command | Description |
 |---------|-------------|
@@ -529,7 +529,7 @@ telad update -dry-run                     # show what would happen
 telad update -h | -? | -help | --help     # print help
 ```
 
-### Environment variables
+### Environment Variables
 
 | Variable | Default | Description |
 |----------|---------|-------------|
@@ -541,7 +541,7 @@ telad update -h | -? | -help | --help     # print help
 | `TELAD_TARGET_HOST` | `127.0.0.1` | Target host for services |
 | `TELAD_MTU` | `1100` | WireGuard tunnel MTU |
 
-### Credential store
+### Credential Store
 
 Store a token so it does not need to appear in config files or shell history:
 
@@ -572,7 +572,7 @@ relays encrypted traffic, and serves the admin API and web console.
 | `-config <path>` | Path to YAML config file |
 | `-v` | Verbose logging |
 
-### Environment variables
+### Environment Variables
 
 | Variable | Default | Description |
 |----------|---------|-------------|
@@ -586,7 +586,7 @@ relays encrypted traffic, and serves the admin API and web console.
 | `TELAHUBD_PORTAL_TOKEN` | (empty) | Portal admin token for registration (used once, not persisted) |
 | `TELAHUBD_PUBLIC_URL` | (empty) | Hub's own public URL for portal registration |
 
-### Config file (`telahubd.yaml`)
+### Config File (`telahubd.yaml`)
 
 ```yaml
 port: 80
@@ -623,7 +623,7 @@ Config file location when running as a service:
 | Linux/macOS | `/etc/tela/telahubd.yaml` |
 | Windows | `%ProgramData%\Tela\telahubd.yaml` |
 
-### `telahubd user` subcommands
+### `telahubd user` Subcommands
 
 Local token management on the hub machine. All subcommands accept `-config <path>`.
 
@@ -641,7 +641,7 @@ Local token management on the hub machine. All subcommands accept `-config <path
 
 Changes take effect immediately. No hub restart required.
 
-### `telahubd portal` subcommands
+### `telahubd portal` Subcommands
 
 | Command | Description |
 |---------|-------------|
@@ -650,7 +650,7 @@ Changes take effect immediately. No hub restart required.
 | `telahubd portal remove <name>` | Remove a portal registration |
 | `telahubd portal sync` | Push viewer token to all registered portals |
 
-### `telahubd service` subcommands
+### `telahubd service` Subcommands
 
 | Command | Description |
 |---------|-------------|
@@ -685,7 +685,7 @@ telahubd update -dry-run                     # show what would happen
 telahubd update -h | -? | -help | --help     # print help
 ```
 
-### Firewall requirements
+### Firewall Requirements
 
 | Port | Protocol | Notes |
 |------|----------|-------|

--- a/book/src/guide/telavisor.md
+++ b/book/src/guide/telavisor.md
@@ -6,7 +6,7 @@ browser, so you can manage connections, hubs, agents, profiles, files, and
 credentials without ever opening a terminal. It runs on Windows, Linux, and
 macOS.
 
-## What TelaVisor is, and what it is not
+## What TelaVisor Is, and What It Is Not
 
 TelaVisor manages the full life cycle of connecting to remote services
 through Tela hubs:
@@ -52,7 +52,7 @@ across all Tela products. The top bar, the mode toggle, the tab bar, the
 toolbar separators, the icon buttons, the modals, and the color system
 that you see in TelaVisor are the canonical examples of TDL.
 
-## Installing and launching
+## Installing and Launching
 
 TelaVisor ships as a single-file native application for each supported
 platform. Download the appropriate build from your configured release
@@ -73,18 +73,19 @@ The application supports light and dark themes. The default is the system
 preference, which you can override in
 [Application Settings](#application-settings).
 
-## The two-mode layout
+## The Two-Mode Layout
 
 TelaVisor uses a two-mode layout. The mode toggle in the center of the
 title bar switches between **Clients** mode and **Infrastructure** mode.
 Each mode has its own tab bar and its own set of features.
 
 - **Clients mode** is for *connecting to remote services*. Its tabs are
-  Status, Profiles, Files, and Client Settings. Read this mode as
+  Status, Profiles, Files, Updates, and Client Settings. Read this mode as
   *everything a user does to use a tunnel*.
 - **Infrastructure mode** is for *administering the system that the
-  tunnels run on*. Its tabs are Hubs, Agents, Remotes, and Credentials.
-  Read this mode as *everything an operator does to keep tunnels working*.
+  tunnels run on*. Its tabs are Hubs, Agents, Access, Remotes, and
+  Credentials. Read this mode as *everything an operator does to keep
+  tunnels working*.
 
 A persistent log panel sits at the bottom of the window across both modes.
 You can drag its top edge to resize it, or click the chevron to collapse
@@ -97,7 +98,7 @@ visit Infrastructure mode. An operator who runs hubs and agents on behalf
 of others spends most of their time in Infrastructure mode. A power user
 moves between both freely.
 
-## Clients mode
+## Clients Mode
 
 ### Status
 
@@ -214,7 +215,7 @@ The Profile Settings panel contains:
 The Profile Settings panel is where you set up things that apply to the
 profile regardless of which machine you are connecting to.
 
-#### Switching profiles
+#### Switching Profiles
 
 The profile dropdown in the toolbar shows every profile in your profile
 directory. Click the dropdown to open the list and select a profile to
@@ -231,7 +232,7 @@ if confirm-disconnect is enabled), then loads the new profile without
 automatically reconnecting. Click the power button in the title bar to
 connect with the new profile.
 
-#### Hub view
+#### Hub View
 
 Clicking a hub in the sidebar shows a summary card for that hub in the
 right panel.
@@ -249,7 +250,7 @@ The hub view is the place to get a quick read on whether the hub has the
 machines you expect. From here you can drill into a specific machine by
 clicking it in the sidebar.
 
-#### Machine view
+#### Machine View
 
 Clicking a machine in the sidebar shows the services that machine
 exposes through the hub.
@@ -308,7 +309,7 @@ enabled. There is no Secure Shell (SSH), no Server Message Block (SMB),
 and no Web Distributed Authoring and Versioning (WebDAV) mount required;
 the file browser talks the file share protocol directly.
 
-#### When the tunnel is down
+#### When the Tunnel Is Down
 
 When the tunnel is not connected, opening the Files tab shows the list
 of machines in the active profile, but the only state you can see is
@@ -320,7 +321,7 @@ You cannot browse files until you connect the profile. The Files tab in
 this state is mostly informational: it tells you which machines are part
 of the active profile and that none of them are reachable yet.
 
-#### When the tunnel is up
+#### When the Tunnel Is Up
 
 When the tunnel is connected, the Files tab shows each machine with its
 file share status: a coloured indicator dot, the machine name, the hub
@@ -341,7 +342,7 @@ read-only in this view. Editing them is done from the
 [Agents tab](#agents) in Infrastructure mode, on a machine where you
 have the manage permission.
 
-#### Browsing files
+#### Browsing Files
 
 Clicking a machine opens its file share in an Explorer-style browser.
 
@@ -528,7 +529,7 @@ The Status field shows whether autostart is currently *Installed* or
 registers a Scheduled Task that triggers at login. On Linux, it writes
 a systemd user unit. On macOS, it installs a LaunchAgent.
 
-## Infrastructure mode
+## Infrastructure Mode
 
 Switching the mode toggle in the title bar to *Infrastructure* changes
 the tab bar to the five administration tabs: Hubs, Agents, Access,
@@ -551,7 +552,7 @@ dropdown, a navigation list of views, and an *Add Hub* button at the
 bottom. The right panel shows the currently selected view for the
 currently selected hub.
 
-#### Hub picker
+#### Hub Picker
 
 The hub picker at the top of the sidebar lists every hub you have
 credentials for. Clicking it opens a dropdown of hub URLs.
@@ -643,7 +644,7 @@ visible to owners and admins:
   `Updated to vX.Y.Z`) and the page re-renders when the hub comes
   back online. The label and disabled state are derived from the
   channel manifest, not from the GitHub `/releases/latest` API, so a
-  hub on `dev` cannot be told to "update to v0.5.0" (the `stable`
+  hub on `dev` cannot be told to "update to v0.15.0" (the `stable`
   HEAD).
 - **Restart.** Requests an immediate graceful restart of the hub
   process.
@@ -726,7 +727,7 @@ currently selected agent. *Undo* and *Save* are enabled when there are
 unsaved changes. *Restart* and *Logs* are always enabled when an agent
 is selected.
 
-#### Agent list
+#### Agent List
 
 When no agent is selected, the right panel is empty with a prompt to
 select one.
@@ -778,7 +779,7 @@ has to land in the agent host's credential store; in that case the
 operator runs `telad pair` directly on the target host, which is the
 flow Generate... is built for.
 
-#### Agent detail
+#### Agent Detail
 
 Selecting an agent in the sidebar shows the agent detail panel on the
 right.
@@ -938,7 +939,7 @@ listed identities as cards, and the Tokens panel that managed
 authentication tokens as a table. Both are gone; this tab is the
 single place to go.
 
-#### Two views of the same data
+#### Two Views of the Same Data
 
 Access opens on one of two projections of the same underlying data:
 
@@ -966,7 +967,7 @@ By machine is the same edit visible in By identity.
 The selected view is persisted to TelaVisor's settings, so reopening
 the tab returns to whichever view the operator last used.
 
-#### The toolbar
+#### The Toolbar
 
 The toolbar across the top of the tab holds the Hub selector and
 every action that operates on the current hub:
@@ -996,7 +997,7 @@ every action that operates on the current hub:
   and the services each grant allows. Useful for compliance and
   for diffing access state over time.
 
-#### The matrix
+#### The Matrix
 
 The matrix is the main working area. Rows are identities (in By
 machine) or machines (in By identity); columns are the three
@@ -1025,7 +1026,7 @@ sidebar item for that row's machine (or identity) picks up the same
 *pending* indicator. Save and Undo in the toolbar are both enabled
 whenever the pending set is non-empty.
 
-#### The Connect services column
+#### The Connect Services Column
 
 The *Connect services* column shows which services the identity can
 reach on the machine when the Connect permission is granted. An
@@ -1065,7 +1066,7 @@ Per-service access control is a v0.15 feature; on older hubs the
 dialog opens in a disabled state with a note explaining that the hub
 must be upgraded before the filter can be used.
 
-#### Save and conflicts
+#### Save and Conflicts
 
 Save fires one write per staged change, in parallel. Each write
 carries the target identity's version as an `If-Match` precondition,
@@ -1090,7 +1091,7 @@ The dialog offers three recovery paths:
 Writes that did not conflict are already committed by the time the
 dialog opens; only the conflicting rows are still pending.
 
-#### The By identity detail header
+#### The By Identity Detail Header
 
 When a user-role identity is selected in By identity, the detail
 header has an action cluster for identity-level operations:
@@ -1182,7 +1183,7 @@ Unix systems and the equivalent restrictive Access Control List (ACL)
 on Windows. The same file is shared with the `tela` CLI, so credentials
 added through TelaVisor are visible to `tela` and vice versa.
 
-## Log panel
+## Log Panel
 
 The log panel is a persistent area at the bottom of the window that
 provides tabbed log output visible across both modes. You can resize it
@@ -1197,7 +1198,7 @@ bottom. Each pane is limited to a configurable maximum number of lines
 (default 5000, configurable in
 [Application Settings](#application-settings)).
 
-### Built-in tabs
+### Built-In Tabs
 
 Three tabs are always present.
 
@@ -1232,7 +1233,7 @@ currently active tab:
 - **Save.** Saves the active tab's content to a file.
 - **Clear.** Clears the active tab.
 
-### Attaching log sources
+### Attaching Log Sources
 
 The `+` button at the right end of the tab strip opens the *attach
 popover*. The popover lists every hub you have credentials for and
@@ -1310,7 +1311,7 @@ The settings are organized into sections.
   log tab in the [Log panel](#log-panel). The default is 5000. Older
   lines are evicted as new ones arrive.
 
-## About dialog
+## About Dialog
 
 The About dialog is opened by clicking the **TelaVisor** title in the
 top-left corner of the title bar, or by clicking the information icon
@@ -1324,7 +1325,7 @@ The dialog is the canonical place to confirm what version of TelaVisor
 and `tela` you are running, and which channels they are configured to
 follow. Use it when filing bug reports.
 
-## Update indicator
+## Update Indicator
 
 When an update is available for any of the binaries TelaVisor manages,
 an orange warning icon appears in the title bar. Clicking the icon
@@ -1343,7 +1344,7 @@ Chocolatey, apt, brew), the self-update mechanism is disabled. Use the
 package manager to update instead. The update indicator will not
 appear in this case.
 
-## Connection status icon
+## Connection Status Icon
 
 The power button in the title bar indicates the current connection
 state at a glance:
@@ -1356,7 +1357,7 @@ You can click the button at any time from any tab to toggle the connection.
 When connected, clicking it disconnects. When disconnected, clicking it
 connects using the current profile.
 
-## System tray
+## System Tray
 
 When *Minimize to tray on close* is enabled in
 [Application Settings](#application-settings), closing the window
@@ -1370,7 +1371,7 @@ again. Right-clicking the tray icon opens a small menu with *Show* and
 The tray feature is useful for keeping a long-running tunnel out of
 the way without committing to installing a system service.
 
-## How TelaVisor works with tela
+## How TelaVisor Works with tela
 
 TelaVisor does not implement WireGuard, gVisor, the hub protocol, the
 agent protocol, or any of the other parts of the Tela fabric directly.
@@ -1407,7 +1408,7 @@ credentials in the local credential file. There is no `tela` child
 process involved in those requests; TelaVisor uses the same hub admin
 endpoints that the CLI's `tela admin` family uses.
 
-## Profile storage
+## Profile Storage
 
 Profiles are stored in the user's application data directory:
 
@@ -1435,7 +1436,7 @@ channel, log lines, attached log tabs) take effect when you click
 *Apply* or *Apply & Close* in the Application Settings dialog and
 persist across restarts.
 
-## Building from source
+## Building from Source
 
 TelaVisor requires [Wails v2](https://wails.io/docs/gettingstarted/installation)
 and its prerequisites: Go 1.25 or newer, Node.js, and the platform

--- a/book/src/guide/three-binaries.md
+++ b/book/src/guide/three-binaries.md
@@ -1,13 +1,13 @@
-# The three binaries
+# The Three Binaries
 
 Tela is built around three cooperating Go binaries. Each one runs from a
 single static executable with no runtime dependencies.
 
-| Binary | Role | Where it runs |
+| Binary | Role | Where It Runs |
 |--------|------|---------------|
 | `telahubd` | Hub relay. Brokers encrypted sessions between agents and clients. Sees only ciphertext. | A publicly reachable server. |
-| `telad` | Agent / daemon. Registers a machine with a hub and exposes selected TCP services through the encrypted tunnel. | The machine you want to reach. |
-| `tela` | Client CLI. Connects to a machine through a hub and binds services on deterministic loopback addresses through the encrypted tunnel. | Any machine you want to connect *from*. |
+| `telad` | Agent, or daemon. Registers a machine with a hub and exposes selected TCP services through the encrypted tunnel. | The machine you want to reach. |
+| `tela` | Client CLI. Connects to a machine through a hub and binds its services on local loopback ports through the encrypted tunnel. | Any machine you want to connect *from*. |
 
 A connection involves all three:
 
@@ -29,13 +29,14 @@ flowchart LR
 ```
 
 Both `tela` and `telad` make outbound connections to the hub. Neither side
-needs to open inbound ports or configure port forwarding. The hub is the only
-component that needs to be publicly reachable.
+needs to open inbound ports or configure port forwarding. The hub is the
+only component that needs to be publicly reachable.
 
 The hub is a blind relay. It pairs clients with agents and forwards
-WireGuard packets between them, but it cannot decrypt the contents -- only
+WireGuard packets between them, but it cannot decrypt the contents; only
 the agent and the client share the keys. Even if the hub is compromised,
 session contents are not exposed.
 
-For the full design rationale, see [Why a connectivity fabric](../architecture/design.md).
-For the CLI surface of each binary, see [Appendix A: CLI reference](reference.md).
+For the full design rationale, see
+[Why a Connectivity Fabric](../architecture/design.md). For the CLI surface
+of each binary, see [Appendix A: CLI Reference](reference.md).

--- a/book/src/guide/upstreams.md
+++ b/book/src/guide/upstreams.md
@@ -1,8 +1,15 @@
 # Upstreams
 
-An upstream is a TCP forwarding rule inside `telad` that intercepts a local service's outbound dependency calls and routes them to a configurable target. A service calls `localhost:5432` expecting to reach its database; `telad` listens on that port and forwards the connection to wherever the database actually is.
+An upstream is a TCP forwarding rule inside `telad` that intercepts a local
+service's outbound dependency calls and routes them to a configurable
+target. A service calls `localhost:5432` expecting to reach its database;
+`telad` listens on that port and forwards the connection to wherever the
+database actually is.
 
-Upstreams start when `telad` starts and run independently of any tunnel session. They provide a dispatch layer that you can change by editing a YAML file, without touching application code, containers, or environment variables.
+Upstreams start when `telad` starts and run independently of any tunnel
+session. They provide a dispatch layer that you can change by editing a
+YAML file, without touching application code, containers, or environment
+variables.
 
 ## Configuration
 
@@ -11,7 +18,8 @@ Upstreams are declared per machine in `telad.yaml`:
 ```yaml
 machines:
   - name: barn
-    ports: [8080]
+    services:
+      - port: 8080
     upstreams:
       - port: 5432
         target: db.internal:5432
@@ -22,9 +30,11 @@ machines:
         name: redis
 ```
 
-`telad` binds port 5432 and port 6379 on all interfaces immediately on startup. Any process on the machine that connects to those ports (including via `localhost`) gets forwarded to the respective targets.
+`telad` binds port 5432 and port 6379 on all interfaces immediately on
+startup. Any process on the machine that connects to those ports (including
+via `localhost`) gets forwarded to the respective targets.
 
-### Field reference
+### Field Reference
 
 | Field | Required | Description |
 |-------|----------|-------------|
@@ -32,13 +42,20 @@ machines:
 | `target` | Yes | Address to forward connections to, in `host:port` form. |
 | `name` | No | Human-readable label used in log output. |
 
-## What upstreams are for
+## What Upstreams Are For
 
-The typical use case is service-to-service dependency routing in development and staging environments.
+The typical use case is service-to-service dependency routing in
+development and staging environments.
 
-A web service configured to connect to `localhost:5432` works against a local database in development. In staging, the database is on a separate machine at `db.staging.internal:5432`. Without upstreams, changing environments means changing the application's configuration, rebuilding a container, or updating environment variables.
+A web service configured to connect to `localhost:5432` works against a
+local database in development. In staging, the database is on a separate
+machine at `db.staging.internal:5432`. Without upstreams, changing
+environments means changing the application's configuration, rebuilding a
+container, or updating environment variables.
 
-With an upstream, the application configuration stays the same in every environment. You change the `target` in `telad.yaml` and restart `telad`. The application never knows the database moved.
+With an upstream, the application configuration stays the same in every
+environment. You change the `target` in `telad.yaml` and restart `telad`.
+The application never knows the database moved.
 
 ```yaml
 # telad.yaml on the staging machine
@@ -48,26 +65,44 @@ upstreams:
     name: postgres
 ```
 
-The application calls `localhost:5432`. `telad` forwards to `db.staging.internal:5432`. No application change required.
+The application calls `localhost:5432`. `telad` forwards to
+`db.staging.internal:5432`. No application change required.
 
-## Upstreams through a Tela tunnel
+## Upstreams Through a Tela Tunnel
 
-The upstream `target` field accepts any reachable `host:port`, including the deterministic loopback addresses that `tela connect` assigns to remote machines. When a machine runs both `telad` (as an agent registering its own services) and `tela` (as a client connected to a remote machine), an upstream can bridge the two.
+The upstream `target` field accepts any reachable `host:port`, including
+the local ports that `tela connect` binds for remote machines. When a
+machine runs both `telad` (as an agent registering its own services) and
+`tela` (as a client connected to a remote machine), an upstream can bridge
+the two.
 
 For example:
 
 - Machine A runs `telad` and exposes a service on port 8080.
-- Machine B runs `tela connect` to machine A. The service on machine A becomes reachable on machine B at `localhost:PORT` -- for example, `localhost:8080` if that port is free, or `localhost:18080` if it is taken. Use `tela status` on machine B to find the exact port.
-- Machine B also runs `telad` with an upstream: `port: 8080, target: localhost:8080` (substitute the actual bound port).
-- Any application on machine B that calls `localhost:8080` reaches the service on machine A through the tunnel.
+- Machine B runs `tela connect` to machine A. The service on machine A
+  becomes reachable on machine B at `localhost:8080` if that port is free,
+  or on a fallback port such as `localhost:18080` if it is taken. Use
+  `tela status` on machine B to find the exact port.
+- Machine B also runs `telad` with an upstream: `port: 8080,
+  target: localhost:8080` (substitute the actual bound port).
+- Any application on machine B that calls `localhost:8080` reaches the
+  service on machine A through the tunnel.
 
-This is an advanced pattern. For most cases, direct service exposure through the tunnel is simpler.
+This is an advanced pattern. For most cases, direct service exposure
+through the tunnel is simpler.
 
-## Upstreams are not gateways
+## Upstreams Are Not Gateways
 
-Upstreams and the path gateway are both forwarding primitives in `telad`, but they operate differently:
+Upstreams and the path gateway are both forwarding primitives in `telad`,
+but they operate differently:
 
-- The **upstream** intercepts outbound calls from services running on the agent machine and routes them to a dependency. It is invisible to the services using it.
-- The **path gateway** accepts inbound HTTP connections through the WireGuard tunnel and routes them to local services by URL path. It is visible to connecting clients as a named service.
+- The **upstream** intercepts outbound calls from services running on the
+  agent machine and routes them to a dependency. It is invisible to the
+  services using it.
+- The **path gateway** accepts inbound HTTP connections through the
+  WireGuard tunnel and routes them to local services by URL path. It is
+  visible to connecting clients as a named service.
 
-Use an upstream when a service needs to reach a dependency at a different address than it expects. Use a gateway when clients connecting through Tela need to reach multiple HTTP services through one tunnel port.
+Use an upstream when a service needs to reach a dependency at a different
+address than it expects. Use a gateway when clients connecting through Tela
+need to reach multiple HTTP services through one tunnel port.

--- a/book/src/howto/channels.md
+++ b/book/src/howto/channels.md
@@ -1,41 +1,60 @@
-# Self-update and release channels
+# Self-Update and Release Channels
 
-## What this covers
+Once you have Tela binaries deployed across more than one machine, you face
+a maintenance question: how do you keep them up to date without logging
+into every machine and running a download by hand?
 
-Once you have Tela binaries deployed across more than one machine, you face a maintenance question: how do you keep them up to date without logging into every machine and running a download by hand?
+Tela's answer is self-update through a release channel system. Each binary
+(`tela`, `telad`, `telahubd`, TelaVisor) knows which channel it is
+following (`dev`, `beta`, or `stable`), fetches the channel's JSON manifest
+from GitHub Releases, and updates itself in place. The update is verified
+against the manifest's SHA-256 before anything is written to disk. Agents
+and hubs can be updated remotely through the hub's management protocol,
+without SSH access to the machine.
 
-Tela's answer is self-update through a release channel system. Each binary -- `tela`, `telad`, `telahubd`, TelaVisor -- knows which channel it is following (`dev`, `beta`, or `stable`), fetches the channel's JSON manifest from GitHub Releases, and updates itself in place. The update is verified against the manifest's SHA-256 before anything is written to disk. Agents and hubs can be updated remotely through the hub's management protocol, without SSH access to the machine.
+This chapter covers how to check what channel any binary is on, switch a
+binary to a different channel, trigger an update from the command line, the
+admin API, or TelaVisor, and bootstrap a fresh machine that does not yet
+have any Tela binary installed.
 
-By the end of this chapter you will know how to:
+The commands below assume at least one Tela binary is already installed and
+on your `PATH`. To get the first binary onto a machine, see
+[Bootstrapping a Fresh Box](#bootstrapping-a-fresh-box) below.
 
-- Check what channel any binary is on and whether an update is available
-- Switch a binary to a different channel
-- Trigger an update from the command line, the admin API, or TelaVisor
-- Bootstrap a fresh machine that does not yet have any Tela binary installed
+For the design model behind channels (what they are, how promotion works,
+when to cut a beta or a stable), see the
+[Release Process](../ops/release-process.md) chapter in the Operations
+section.
 
-The commands below assume at least one Tela binary is already installed and on your `PATH`. To get the first binary onto a machine, see [Bootstrapping a fresh box](#bootstrapping-a-fresh-box) below.
+## The Mental Model in One Paragraph
 
-For the design model behind channels (what they are, how promotion works, when to cut a beta or a stable), see the [Release process](../ops/release-process.md) chapter in the Operations section.
+Tela ships through three channels. **dev** updates on every commit to main.
+**beta** is a dev build that a maintainer judged ready for promotion.
+**stable** is a beta build promoted to the conservative line. Each channel
+is described by a JSON manifest hosted on GitHub Releases that names the
+current tag and lists every binary published under that tag with its
+SHA-256. Every Tela binary follows whichever channel it is configured for,
+fetches the matching manifest, and verifies the SHA-256 against the
+manifest entry before installing an update. You can switch a binary's
+channel at any time, and the channel is per-binary, not global: you can run
+a `dev` agent against a `stable` hub.
 
-## The mental model in one paragraph
+## Inspecting Channels
 
-Tela ships through three channels. **dev** updates on every commit to main. **beta** is a dev build that a maintainer judged ready for promotion. **stable** is a beta build that has been deemed ready for promotion to the conservative line. Each channel is described by a JSON manifest hosted on GitHub Releases that names the current tag and lists every binary published under that tag with its SHA-256. Every Tela binary -- the `tela` client, `telad` agent, `telahubd` hub, and TelaVisor desktop app -- follows whichever channel it's configured for, fetches the matching manifest, and verifies SHA-256 against the manifest entry before installing an update. You can switch a binary's channel at any time, and the channel is per-binary, not global -- you can run a `dev` agent against a `stable` hub.
-
-## Inspecting channels
-
-### From the command line
+### From the Command Line
 
 ```bash
 tela channel
 ```
 
-prints the current client's channel, the manifest URL, the running version, and the latest version on that channel:
+prints the current client's channel, the manifest URL, the running version,
+and the latest version on that channel:
 
 ```text
   channel:         dev
   manifest:        https://github.com/paulmooreparks/tela/releases/download/channels/dev.json
-  current version: v0.6.0-dev.7
-  latest version:  v0.6.0-dev.8  (update available)
+  current version: v0.16.0-dev.14
+  latest version:  v0.16.0-dev.15  (update available)
 ```
 
 To inspect a channel without switching to it:
@@ -44,59 +63,74 @@ To inspect a channel without switching to it:
 tela channel show -channel beta
 ```
 
-That prints the parsed channel manifest: every binary on that channel with its size and SHA-256.
+That prints the parsed channel manifest: every binary on that channel with
+its size and SHA-256.
 
-### For a remote hub
+### For a Remote Hub
 
 ```bash
 tela admin hub channel -hub <hub-name>
 ```
 
-prints the same shape but for the hub at `<hub-name>` instead of the local client. Requires an owner or admin token on the hub.
+prints the same shape but for the hub at `<hub-name>` instead of the local
+client. Requires an owner or admin token on the hub.
 
-### For a remote agent
+### For a Remote Agent
 
 ```bash
 tela admin agent channel -hub <hub-name> -machine <machine-id>
 ```
 
-The hub forwards the request to the named agent and returns its channel and version state.
+The hub forwards the request to the named agent and returns its channel and
+version state.
 
 ### From TelaVisor
 
-The same information appears in three places, as `Release channel` rows in:
+The same information appears in three places:
 
-- **Hub Settings → Management** (per-hub)
-- **Agent Settings → Management** (per-agent)
-- **Application Settings → Updates** (TelaVisor's own preference)
+- The **Updates tab** (Clients mode) shows the channel that TelaVisor and
+  the `tela` CLI follow on this machine, in the Release Channel card.
+- The **Hubs tab** (Infrastructure mode) shows each hub's channel in the
+  Management section of Hub Settings.
+- The **Agents tab** (Infrastructure mode) shows each agent's channel in
+  the Management card of the agent detail panel.
 
-The dropdowns are channel selectors and the trailing status text shows the current/latest versions, exactly like the CLI output.
+The dropdowns are channel selectors, and the trailing status text shows the
+current and latest versions, exactly like the CLI output.
 
-### From Awan Saya
+### From a Portal
 
-The portal also has channel rows in the Hub and Agent management cards. Same shape, gated on having the manage permission on the hub or agent.
+Portals such as Awan Saya show the same channel rows in their hub and agent
+management cards, gated on having the manage permission on the hub or
+agent.
 
-## Switching channels
+## Switching Channels
 
-### The client (and TelaVisor)
+### The Client (and TelaVisor)
 
 ```bash
 tela channel set beta
 ```
 
-writes the preference to the user credential store (`~/.tela/credentials.yaml` on Unix, `%APPDATA%\tela\credentials.yaml` on Windows). Both the `tela` CLI and TelaVisor read from this file, so the next time either runs `update` it follows the new channel.
+writes the preference to the user credential store
+(`~/.tela/credentials.yaml` on Unix, `%APPDATA%\tela\credentials.yaml` on
+Windows). Both the `tela` CLI and TelaVisor read from this file, so the
+next time either runs `update` it follows the new channel.
 
-You can also change it from TelaVisor's Application Settings → Updates → Release channel dropdown.
+You can also change it from the Release Channel dropdown on TelaVisor's
+Updates tab.
 
-### A hub
+### A Hub
 
-From any workstation with an owner/admin token:
+From any workstation with an owner or admin token:
 
 ```bash
 tela admin hub channel set beta -hub <hub-name>
 ```
 
-PATCHes `/api/admin/update` on the hub. The hub persists `update.channel` to its YAML config. The change takes effect on the next self-update; the currently running binary is not affected.
+This sends `PATCH /api/admin/update` to the hub. The hub persists
+`update.channel` to its YAML config. The change takes effect on the next
+self-update; the currently running binary is not affected.
 
 Directly on the hub machine, you can do the same without an admin token:
 
@@ -104,11 +138,17 @@ Directly on the hub machine, you can do the same without an admin token:
 sudo telahubd channel set beta
 ```
 
-This writes `update.channel` in the hub's YAML config (the platform-standard path is the default, so you rarely need `-config`). Restart the hub service for background update checks to pick up the new channel. Run `telahubd channel -h` for the full subcommand list, including `telahubd channel show` which prints the full parsed manifest.
+This writes `update.channel` in the hub's YAML config (the
+platform-standard path is the default, so you rarely need `-config`).
+Restart the hub service for background update checks to pick up the new
+channel. Run `telahubd channel -h` for the full subcommand list, including
+`telahubd channel show`, which prints the full parsed manifest.
 
-You can also change it from TelaVisor's Hub Settings → Management → Release channel dropdown, or from the equivalent dropdown in Awan Saya's hub management card.
+You can also change it from the Release Channel dropdown in TelaVisor's
+Hub Settings, or from the equivalent dropdown in a portal's hub management
+card.
 
-### An agent
+### An Agent
 
 From any workstation with permissions:
 
@@ -116,7 +156,9 @@ From any workstation with permissions:
 tela admin agent channel -hub <hub-name> -machine <machine-id> set beta
 ```
 
-The hub forwards the `update-channel` mgmt action to the agent, which persists `update.channel` to its `telad.yaml`. Same UI in TelaVisor's Agent Settings.
+The hub forwards the `update-channel` management action to the agent, which
+persists `update.channel` to its `telad.yaml`. The same control is in the
+Management card of TelaVisor's agent detail panel.
 
 Directly on the agent machine:
 
@@ -124,13 +166,16 @@ Directly on the agent machine:
 sudo telad channel set beta -config /etc/tela/telad.yaml
 ```
 
-Or set `TELAD_CONFIG` in the environment and drop the flag. Run `telad channel -h` for the full subcommand list, including `telad channel show` which prints the full parsed manifest.
+Or set `TELAD_CONFIG` in the environment and drop the flag. Run
+`telad channel -h` for the full subcommand list, including
+`telad channel show`, which prints the full parsed manifest.
 
 ## Updating
 
-Three ways to update, all read from the same channel manifest. Pick whichever fits the box.
+Three ways to update, all reading from the same channel manifest. Pick
+whichever fits the box.
 
-### Self-update via the binary's own CLI
+### Self-Update via the Binary's Own CLI
 
 ```bash
 tela update                           # update the running tela client
@@ -138,11 +183,20 @@ telad update                          # update the on-disk telad binary
 telahubd update                       # update the on-disk telahubd binary
 ```
 
-All three accept `-channel <name>` (one-shot override, accepts any valid channel name including custom ones), `-dry-run` (show what would happen without modifying the binary), and `-h` / `-?` / `-help` / `--help` (print usage). For `telad` and `telahubd`, the `-config <path>` flag selects which YAML config file's channel to honor.
+All three accept `-channel <name>` (one-shot override, accepts any valid
+channel name including custom ones), `-dry-run` (show what would happen
+without modifying the binary), and `-h` / `-?` / `-help` / `--help` (print
+usage). For `telad` and `telahubd`, the `-config <path>` flag selects which
+YAML config file's channel to honor.
 
-The download is verified against the channel manifest's SHA-256 before being written. On Windows the running `.exe` is renamed to `.exe.old` before the new binary is moved into place; the `.old` file is removed in the background. On Unix the rename is atomic.
+The download is verified against the channel manifest's SHA-256 before
+being written. On Windows the running `.exe` is renamed to `.exe.old`
+before the new binary is moved into place; the `.old` file is removed in
+the background. On Unix the rename is atomic.
 
-For `telad` and `telahubd` running as managed OS services, the binary is swapped in place but the running process is not killed. Restart the service manually for the new binary to take effect:
+For `telad` and `telahubd` running as managed OS services, the binary is
+swapped in place but the running process is not killed. Restart the service
+manually for the new binary to take effect:
 
 ```bash
 sudo systemctl restart telad           # systemd
@@ -150,26 +204,39 @@ sudo launchctl kickstart -k system/com.tela.telad   # launchd
 sc stop telad && sc start telad        # Windows SCM
 ```
 
-### Self-update via the admin API
+### Self-Update via the Admin API
 
 ```bash
 tela admin hub update -hub <hub-name>
 tela admin agent update -hub <hub-name> -machine <machine-id>
 ```
 
-The hub or agent downloads the new binary from its configured channel, verifies it, and restarts. For agents the restart goes through whatever process supervision they're under (Docker, Windows SCM, systemd, launchd, or none). For hubs the same applies.
+The hub or agent downloads the new binary from its configured channel,
+verifies it, and restarts. The restart goes through whatever process
+supervision the binary is under (Docker, Windows SCM, systemd, launchd, or
+none).
 
-### Self-update from TelaVisor
+### Self-Update from TelaVisor
 
-The Software row in each Management card has an `Update to vX.Y.Z` button when the binary is behind. Clicking it triggers the same admin-API path as above and polls the binary's reported version until it changes, so the table reflects the actual installed version.
+The Software row in each Management card (Hub Settings for hubs, the agent
+detail panel for agents) has an `Update to vX.Y.Z` button when the binary
+is behind. Clicking it triggers the same admin-API path as above and polls
+the binary's reported version until it changes, so the display reflects the
+actual installed version.
 
-For locally installed services, the Installed Tools table on the Updates tab has Update buttons that delegate to the elevated service process (TelaVisor itself does not need to be elevated to update an elevated service binary -- the running service updates itself from the inside, then the process supervisor restarts it against the new binary).
+For locally installed binaries and services, the Installed Tools table on
+the Updates tab has Update buttons. TelaVisor itself does not need to be
+elevated to update an elevated service binary; the running service updates
+itself from the inside, then the process supervisor restarts it against the
+new binary.
 
-## Bootstrapping a fresh box
+## Bootstrapping a Fresh Box
 
-The first time you put Tela on a machine, you don't have a `tela`/`telad`/`telahubd` binary yet, so you can't use any of the self-update commands. You need to download one binary by hand, then let it self-update from the channel manifest forever after.
+The first time you put Tela on a machine, you do not have a binary yet, so
+you cannot use any of the self-update commands. Download one binary by
+hand, then let it self-update from the channel manifest forever after.
 
-### One-liner from a Linux shell
+### One-Liner from a Linux Shell
 
 ```bash
 curl -fsSL https://github.com/paulmooreparks/tela/releases/download/channels/dev.json \
@@ -179,18 +246,22 @@ chmod +x telad-linux-amd64
 sudo mv telad-linux-amd64 /usr/local/bin/telad
 ```
 
-Replace `dev.json` with `beta.json` or `stable.json` to bootstrap from a different channel. Replace `telad-linux-amd64` with whichever binary you want (`tela-linux-arm64`, `telahubd-darwin-amd64`, etc).
+Replace `dev.json` with `beta.json` or `stable.json` to bootstrap from a
+different channel. Replace `telad-linux-amd64` with whichever binary you
+want (`tela-linux-arm64`, `telahubd-darwin-amd64`, and so on).
 
-### One-liner from PowerShell
+### One-Liner from PowerShell
 
 ```powershell
 $m = Invoke-RestMethod https://github.com/paulmooreparks/tela/releases/download/channels/dev.json
 Invoke-WebRequest ($m.downloadBase + 'tela-windows-amd64.exe') -OutFile tela.exe
 ```
 
-### From an existing tela on a different box
+### From an Existing tela on a Different Box
 
-If you already have one machine with `tela` installed, the easiest way to put a binary on a new machine is to download it from the existing one and copy it over:
+If you already have one machine with `tela` installed, the easiest way to
+put a binary on a new machine is to download it from the existing one and
+copy it over:
 
 ```bash
 tela channel download telad-linux-amd64 -o telad
@@ -198,53 +269,85 @@ scp telad newhost:/tmp/telad
 ssh newhost 'sudo mv /tmp/telad /usr/local/bin/telad && sudo chmod +x /usr/local/bin/telad'
 ```
 
-After the transfer, every subsequent update on the new box is just `telad update`.
+After the transfer, every subsequent update on the new box is just
+`telad update`.
 
-## Verifying a download by hand
+## Verifying a Download by Hand
 
-Every download Tela does internally is SHA-256-verified against the channel manifest, but if you want to verify a download yourself (because you fetched it with `wget` or out of habit), every release also publishes a `SHA256SUMS.txt` asset alongside the binaries:
+Every download Tela performs internally is SHA-256-verified against the
+channel manifest, but if you want to verify a download yourself (because
+you fetched it with `wget` or out of habit), every release also publishes a
+`SHA256SUMS.txt` asset alongside the binaries:
 
 ```bash
-curl -fLO https://github.com/paulmooreparks/tela/releases/download/v0.6.0-dev.8/SHA256SUMS.txt
-curl -fLO https://github.com/paulmooreparks/tela/releases/download/v0.6.0-dev.8/telad-linux-amd64
+curl -fLO https://github.com/paulmooreparks/tela/releases/download/v0.16.0-dev.15/SHA256SUMS.txt
+curl -fLO https://github.com/paulmooreparks/tela/releases/download/v0.16.0-dev.15/telad-linux-amd64
 sha256sum -c SHA256SUMS.txt --ignore-missing
 ```
 
-## What happens during an update, in detail
+## What Happens During an Update, in Detail
 
 For an interactive `tela update`:
 
 1. Read the configured channel from the user credential store.
 2. Fetch the channel manifest (5-minute in-process cache).
 3. Look up the entry for `tela-{goos}-{goarch}{ext}` in the manifest.
-4. Compare current version against `manifest.version`. If equal and the running binary is not a `dev` build, exit "already up to date."
+4. Compare the current version against `manifest.version`. If equal and the
+   running binary is not a `dev` build, exit "already up to date."
 5. Download the binary from `manifest.downloadBase + binary-name`.
-6. Stream the body through `channel.VerifyReader`, which writes to a sibling tmp file in the destination directory while computing a SHA-256 hash and counting bytes. If the hash or size does not match the manifest entry, delete the tmp file and exit non-zero.
-7. On Unix, rename tmp to destination atomically. On Windows, rename current binary to `.old`, rename tmp to destination, then remove `.old` in the background.
+6. Stream the body through the verifier, which writes to a sibling tmp file
+   in the destination directory while computing a SHA-256 hash and counting
+   bytes. If the hash or size does not match the manifest entry, delete the
+   tmp file and exit non-zero.
+7. On Unix, rename tmp to destination atomically. On Windows, rename the
+   current binary to `.old`, rename tmp to destination, then remove `.old`
+   in the background.
 8. Print `OK: tela updated to vX.Y.Z`.
 
-The same steps happen for `telad update` and `telahubd update`, and for the admin-API-driven updates with the difference that the new binary is staged and the running process exits, leaving the OS service manager (or the user) to relaunch.
+The same steps happen for `telad update` and `telahubd update`. For
+admin-API-driven updates the difference is that the new binary is staged
+and the running process exits, leaving the OS service manager (or the user)
+to relaunch it.
 
-## When things go wrong
+## When Things Go Wrong
 
 ### "fetch dev manifest: HTTP 404"
 
-The channel manifest URL did not return a manifest. Either the manifest base URL is wrong (you set a `sources[<channel>]` override that points nowhere), or GitHub is having a bad day. Check the URL printed by `tela channel`.
+The channel manifest URL did not return a manifest. Either the manifest
+base URL is wrong (you set a `sources[<channel>]` override that points
+nowhere), or GitHub is having a bad day. Check the URL printed by
+`tela channel`.
 
 ### "verify download: sha256 mismatch"
 
-The downloaded binary did not match the manifest entry. This is the safety net working: a corrupted download or a manifest/asset mismatch will fail here rather than installing a bad binary. The tmp file is removed automatically. Try again. If it persists, the manifest itself may be stale -- run `tela channel show` to inspect.
+The downloaded binary did not match the manifest entry. This is the safety
+net working: a corrupted download or a manifest/asset mismatch fails here
+rather than installing a bad binary. The tmp file is removed automatically.
+Try again. If it persists, the manifest itself may be stale; run
+`tela channel show` to inspect it.
 
-### "requested version vX.Y.Z is not the current vA.B.C on channel <ch>"
+### "requested version vX.Y.Z is not the current vA.B.C on channel"
 
-You asked for a specific version that is not the channel's current HEAD. Channels are always-current pointers, not version pins. To get an older or newer version, switch channels (or set a custom `sources[<channel>]` URL). Pre-1.0 there is no other way to pin.
+You asked for a specific version that is not the channel's current HEAD.
+Channels are always-current pointers, not version pins. To get an older or
+newer version, switch channels (or set a custom `sources[<channel>]` URL).
+Pre-1.0 there is no other way to pin.
 
-### TelaVisor's Update button shows "pre-channel build"
+### TelaVisor's Update Button Shows "pre-channel build"
 
-The hub or agent is running a binary from before the channel system was added. Update it via the legacy path first (run `telahubd update` or `telad update` from a shell on the box, or use the bootstrap one-liner above), and the channel-aware UI will start working on the next page load.
+The hub or agent is running a binary from before the channel system was
+added. Update it once from a shell on the box (`telahubd update` or
+`telad update`, or the bootstrap one-liner above), and the channel-aware UI
+will start working on the next page load.
 
 ## Related
 
-- [Release process](../ops/release-process.md) -- the channel model, promotion, and running a self-hosted channel server on telahubd
-- [Appendix A: CLI reference](../guide/reference.md) -- full CLI reference for `tela channel`, `tela update`, `telad update`, `telahubd update`, `telahubd channels publish`, `tela admin hub channel`, `tela admin agent channel`
-- [Appendix B: Configuration file reference](../guide/configuration.md) -- the `update.channel`, `update.sources`, and `channels:` fields in `telad.yaml`, `telahubd.yaml`, and `credentials.yaml`
+- [Release Process](../ops/release-process.md): the channel model,
+  promotion, and running a self-hosted channel server on telahubd
+- [Appendix A: CLI Reference](../guide/reference.md): full CLI reference
+  for `tela channel`, `tela update`, `telad update`, `telahubd update`,
+  `telahubd channels publish`, `tela admin hub channel`, and
+  `tela admin agent channel`
+- [Appendix B: Configuration File Reference](../guide/configuration.md):
+  the `update.channel`, `update.sources`, and `channels:` fields in
+  `telad.yaml`, `telahubd.yaml`, and `credentials.yaml`

--- a/book/src/howto/gateway.md
+++ b/book/src/howto/gateway.md
@@ -1,69 +1,46 @@
-# Set up a path-based gateway
+# Set Up a Path-Based Gateway
 
-## What you are setting up
+This walkthrough configures a path gateway on a real development stack and
+verifies it end to end. The concept, the full field reference, and the
+route-matching rules are in [The Path Gateway](../guide/gateway.md); this
+chapter is the worked example.
 
-Picture a development machine running three HTTP services on different ports: a React frontend on port 3000, a REST API on port 4000, and a metrics endpoint on port 4100. Without a gateway, a colleague connecting through Tela would get three separate loopback bindings -- one per service port -- and the browser would see them as three different origins, triggering Cross-Origin Resource Sharing (CORS) issues every time the frontend calls the API.
+## The Starting Point
 
-The path-based gateway solves this by exposing a single tunnel port (for example, 8080) that routes incoming HTTP requests to the right local service based on the URL path prefix. Your colleague connects to one address and one port. The browser sends all requests -- frontend, API calls, metrics -- to the same origin. No CORS. No extra configuration on the application side.
+A development machine named `launchpad` runs three HTTP services on
+different ports: a React frontend on port 3000, a REST API on port 4000,
+and a metrics endpoint on port 4100. It also runs PostgreSQL on port 5432.
+The machine already has `telad` registered with a hub (see
+[Run an Agent](telad.md) if it does not).
 
-When this chapter is done, a client connecting to your machine will see:
+Without a gateway, a colleague connecting through Tela gets three separate
+loopback bindings, one per HTTP port, and the browser treats them as three
+different origins. Every frontend call to the API is a cross-origin
+request, which means Cross-Origin Resource Sharing (CORS) headers, a
+configurable API URL in the UI code, or an extra proxy.
+
+When this walkthrough is done, the colleague sees one binding:
 
 ```
 Services available:
   localhost:8080   → HTTP
+  localhost:5432   → port 5432
 ```
 
-Requests to `http://localhost:8080/` go to the frontend. Requests to `http://localhost:8080/api/` go to the API. Requests to `http://localhost:8080/metrics/` go to the metrics endpoint. The routing is defined in your `telad.yaml` and takes effect without restarting anything except `telad`.
+Requests to `http://localhost:8080/` reach the frontend, `/api/...` reaches
+the API, and `/metrics/...` reaches the metrics endpoint, all on one
+origin. No CORS. No changes to the application.
 
-The gateway is built into `telad`. It requires a few lines of YAML -- no separate binary, no nginx, no Caddy inside the tunnel.
+## Step 1: Add the Gateway to telad.yaml
 
-For the design rationale and the broader gateway primitive family, see the [Gateways](../architecture/gateway.md) chapter in the Design Rationale section.
-
-## When you want a gateway
-
-Use a gateway when you have several HTTP services on one machine and you want to reach all of them through a single tunnel port. Typical examples:
-
-- A web frontend, a REST API, and a metrics endpoint, all served from the same host
-- A multi-page web app with backend services on different ports
-- A development stack you want to demo to a colleague through one URL
-
-You do **not** need a gateway when:
-
-- You only have one HTTP service. Just expose it as a normal service.
-- Your services use TCP, not HTTP. The gateway only proxies HTTP. Expose them as normal TCP services.
-- You already use nginx or Caddy in production and you want to keep that as your edge proxy. The gateway is for tunnel-internal routing, not for public HTTPS termination.
-
-## What a gateway looks like to a user
-
-Without a gateway, a developer connecting to a multi-service app gets one binding per service port:
-
-```
-localhost:3000   → port 3000
-localhost:4000   → port 4000
-localhost:4100   → port 4100
-```
-
-The browser opens `http://localhost:3000` and tries to call the API. The API is on a different origin (`localhost:4000`) -- same host, different port, which still triggers Cross-Origin Resource Sharing (CORS) in the browser. The UI has to be configured with the API URL, or there has to be an extra proxy layer somewhere.
-
-With a gateway, the developer gets one binding:
-
-```
-localhost:8080   → HTTP
-```
-
-Opening `http://localhost:8080/` serves the UI. The UI calls `/api/users`. The gateway sees the `/api/` prefix and proxies the request to the local API service. Same origin. No CORS. No extra config.
-
-## Configuring the gateway
-
-Gateway configuration lives in the `telad.yaml` file under each machine, alongside the `services:` list. A minimal example:
+On `launchpad`, extend the machine entry with a `gateway:` block:
 
 ```yaml
-hub: wss://your-hub.example.com
-token: "<your-agent-token>"
+hub: wss://hub.example.com
+token: "<agent-token>"
 
 machines:
   - name: launchpad
-    target: 127.0.0.1
     services:
       - port: 5432
         name: postgres
@@ -79,140 +56,79 @@ machines:
           target: 3000
 ```
 
-What this declares:
+The three HTTP services are deliberately not in the `services:` list. They
+are private to the machine and reachable only through the gateway. The
+tunnel exposes port 8080 (the gateway) and port 5432 (PostgreSQL). Routes
+match by longest path prefix, so `/api/v2/users` would go to a `/api/v2/`
+route before `/api/`, regardless of the order in the file.
 
-- A machine named `launchpad`
-- One direct TCP service: PostgreSQL on port 5432 (exposed through the tunnel like any normal service)
-- A gateway listening on port 8080 with three routes:
-  - `/api/...` proxies to local port 4000
-  - `/metrics/...` proxies to local port 4100
-  - `/` (the catch-all) proxies to local port 3000
+Restart `telad` to apply the change. At startup it logs the route table it
+loaded, which is worth a glance the first time.
 
-The HTTP services on ports 3000, 4000, and 4100 are **not** in the `services:` list. They are private to the machine and reachable only through the gateway. The tunnel exposes only port 8080 (the gateway) and port 5432 (PostgreSQL).
+## Step 2: Add the Gateway to the Client Profile
 
-### Field reference
-
-| Field | Required | Description |
-|-------|----------|-------------|
-| `gateway.port` | Yes | Port the gateway listens on inside the WireGuard tunnel. Does not need to match any local service port. |
-| `gateway.routes` | Yes | List of routes, each mapping a URL path prefix to a local target port. |
-| `routes[].path` | Yes | URL path prefix to match (e.g. `/api/`, `/admin/`, `/`). |
-| `routes[].target` | Yes | Local TCP port to forward matched requests to (e.g. `4000`). |
-
-### Route matching
-
-Routes are matched by **longest path prefix first**. Order in the YAML does not matter; `telad` sorts them at startup. A route with `path: /` is the catch-all and matches any request not handled by a more specific route.
-
-For example, with these routes:
-
-```yaml
-routes:
-  - path: /
-    target: 3000
-  - path: /api/v2/
-    target: 4002
-  - path: /api/
-    target: 4000
-```
-
-A request to `/api/v2/users` matches `/api/v2/` (target 4002), not `/api/` (which is shorter) and not `/` (which is even shorter).
-
-A request to `/api/health` matches `/api/` (target 4000) because `/api/v2/` is not a prefix.
-
-A request to `/about` matches `/` (target 3000).
-
-## Connecting to a gateway
-
-The gateway shows up to clients as a normal service named `gateway`. List it like any other service in your connection profile:
+The gateway appears to clients as a service named `gateway`. On the
+connecting machine:
 
 ```yaml
 # ~/.tela/profiles/launchpad.yaml
 connections:
-  - hub: wss://your-hub.example.com
+  - hub: wss://hub.example.com
     machine: launchpad
     services:
       - name: gateway
       - name: postgres
 ```
-
-Then connect:
 
 ```bash
 tela connect -profile launchpad
 ```
 
-You will see:
+The output lists `localhost:8080 → HTTP`. If port 8080 is taken on the
+client machine, either accept the fallback port the output shows or pin a
+different one with `local: 18080` on the gateway service entry.
 
-```
-Services available:
-  localhost:8080   → HTTP
-  localhost:5432   → port 5432
-```
+## Step 3: Verify
 
-Port labels come from the well-known port table (22=SSH, 80/8080=HTTP, 3389=RDP, etc.). Ports not in the table show as `port N`.
+Open `http://localhost:8080/` in a browser: the frontend loads from local
+port 3000 on `launchpad`. Open the browser's network inspector and trigger
+an API call: `/api/...` requests return from the API on port 4000, same
+origin, no CORS preflight failures. `curl http://localhost:8080/metrics/`
+returns the metrics endpoint.
 
-Open `http://localhost:8080/` in a browser. The gateway serves the UI from local port 3000. API calls to `/api/...` are routed to local port 4000. Metrics calls to `/metrics/...` are routed to local port 4100.
+## Optional: Direct Access for Debugging
 
-### Renaming the local port
-
-If `8080` clashes with something already running on your machine, override the local port the same way you do for any service:
-
-```yaml
-connections:
-  - hub: wss://your-hub.example.com
-    machine: launchpad
-    services:
-      - name: gateway
-        local: 18080
-      - name: postgres
-        local: 15432
-```
-
-Now the gateway is at `http://localhost:18080/` instead of port 8080. The gateway port on the agent side is still 8080.
-
-### Direct access alongside the gateway
-
-You can connect to a gateway **and** an underlying service directly at the same time. To get direct API access for `curl`/Postman/debugging, list the API as a normal service in the agent's `services:` list (in addition to the gateway), then include both in your profile:
+To also reach the API directly with `curl` or Postman, bypassing the
+gateway, expose it as a named service alongside the gateway and give it an
+explicit local port in the profile:
 
 ```yaml
-# telad.yaml on the agent
-machines:
-  - name: launchpad
+# telad.yaml addition
     services:
+      - port: 5432
+        name: postgres
+        proto: tcp
       - port: 4000
         name: api
         proto: http
-    gateway:
-      port: 8080
-      routes:
-        - path: /api/
-          target: 4000
-        - path: /
-          target: 3000
 ```
 
 ```yaml
-# client profile
-connections:
-  - hub: wss://your-hub.example.com
-    machine: launchpad
+# profile addition
     services:
       - name: gateway
+      - name: postgres
       - name: api
         local: 14000
 ```
 
-Now you have:
+Now `http://localhost:8080/api/users` goes through the gateway and
+`http://localhost:14000/users` hits the API directly.
 
-- `http://localhost:8080/` -- the UI through the gateway
-- `http://localhost:8080/api/users` -- the API through the gateway (path-routed)
-- `http://localhost:14000/users` -- the API directly (bypassing the gateway)
+## Optional: The Same App in Two Environments
 
-This is useful when you want the browser experience for normal use and the direct port for debugging.
-
-## Cross-environment scenarios
-
-The gateway becomes especially useful when you maintain the same application across multiple environments (dev, staging, prod) on different hubs. Each environment runs its own `telad` with its own gateway config. A developer who wants to compare two environments side by side can connect to both:
+When the same application runs in several environments, each with its own
+`telad` and gateway config, one profile can connect to both side by side:
 
 ```yaml
 connections:
@@ -228,39 +144,48 @@ connections:
         local: 18080
 ```
 
-When connecting to both environments simultaneously, use `local:` overrides to put them on different ports. Without an override, both gateways would try to bind `localhost:8080` and the second would fall back to `localhost:18080`. Making it explicit avoids relying on fallback behavior. Open two browser tabs, one per port, and both show the same URL path structure since the gateway routes are defined in each environment's `telad.yaml`.
-
-## What the gateway does not do
-
-The gateway is intentionally minimal. It does **not**:
-
-- Terminate TLS. The WireGuard tunnel already provides end-to-end encryption between the client and `telad`. Adding TLS inside the tunnel would be redundant.
-- Authenticate users. Connection-level auth is handled by Tela's hub tokens and access control lists. Application-level auth (login forms, OAuth, JWT) is the application's responsibility, the same as it would be without Tela.
-- Load-balance. Each `telad` instance serves one machine. There is nothing to balance across.
-- Transform requests or responses. It is a transparent proxy. The request the browser sends is the request the local service receives, except that the `Host` header is rewritten to the local target.
-- Proxy WebSockets. WebSocket upgrade is not supported in the gateway itself. If you need WebSocket access to a service, expose it as a normal service alongside the gateway.
-- Replace a production internet-facing reverse proxy. For internet-facing TLS termination, rate limiting, web application firewall rules, and load balancing, you still want nginx, Caddy, Traefik, or a managed edge service. The gateway is for the path inside the tunnel.
+Give the second gateway an explicit `local:` port so you are not relying on
+fallback behavior, then open one browser tab per port. The URL path
+structure is identical in both, because the routing lives in each
+environment's `telad.yaml`, not in the client profile.
 
 ## Troubleshooting
 
-**The gateway port shows up but requests return 502 or "connection refused".**
+**The gateway port shows up but requests return 502 or "connection
+refused".** The gateway accepted the request but could not reach the local
+target service. Check that the target port (for example 4000) is actually
+listening on `127.0.0.1` on the agent machine. If the service runs in a
+Docker container, publish the container's port to the host or point
+`target` at `host.docker.internal`. If the service is bound to a specific
+non-loopback interface, the gateway will not reach it.
 
-The gateway accepted the request but could not reach the local target service. Check that the target port (e.g. `4000`) is actually listening on `127.0.0.1` on the agent machine. If the service is in a Docker container, make sure the container's port is published to the host or that `target` points at `host.docker.internal`. If the service is bound to a specific interface (not `0.0.0.0` or `127.0.0.1`), the gateway will not reach it.
+**The browser hits the wrong route.** Matching is by longest path prefix.
+If `/api/users` is landing on the `/` route, the `/api/` route is probably
+missing its trailing slash, or another route is unexpectedly more specific.
+Check the route table `telad` logs at startup (via
+`journalctl -u telad`, the Windows Event Viewer, or
+`tela admin agent logs -machine launchpad`).
 
-**The browser hits the wrong route.**
+**The gateway port is not in the connection's local listeners.** Verify
+the client profile lists `gateway` as a service. The gateway is exposed by
+name, not by port number.
 
-Remember that matching is by longest path prefix. If you intend for `/api/users` to match `/api/` but it is matching `/`, your `/api/` route is missing the trailing slash, or one of your other routes is incorrectly more specific. Check the agent's logs (`telad service logs` if running as a service, or stderr otherwise) for the route table that telad logs at startup.
+**A service that worked as a normal service stops working when moved
+behind the gateway.** Make sure the service is no longer in the
+`services:` list, or is intentionally exposed both ways as in the
+direct-access setup above. If a normal service entry on port 4000 and a
+gateway route to port 4000 both exist unintentionally, the client may
+connect to the wrong one depending on profile order.
 
-**The gateway port is not in the connection's local listeners.**
+**A WebSocket-dependent app misbehaves behind the gateway.** Expose that
+service directly as a TCP service alongside the gateway and connect to it
+on its own port.
 
-Verify the client profile lists `gateway` as a service. The gateway is exposed by name, not by port number.
+## See Also
 
-**A service that worked as a normal service stops working when moved behind the gateway.**
-
-Make sure the service is not in the `services:` list anymore (or is intentionally exposed both ways for direct access). If both a normal service entry on port 4000 and a gateway route to port 4000 exist, the client may end up connecting to the wrong one depending on profile order.
-
-## See also
-
-- [Gateways](../architecture/gateway.md) -- design rationale and the broader gateway primitive family
-- [Run an agent](telad.md) -- general `telad` configuration including the bridge agent deployment pattern
-- [Upstreams](../guide/upstreams.md) -- the outbound dependency routing counterpart to the path gateway
+- [The Path Gateway](../guide/gateway.md): concept, configuration
+  reference, and route-matching rules
+- [Run an Agent](telad.md): general `telad` configuration, including the
+  bridge deployment pattern
+- [Upstreams](../guide/upstreams.md): the outbound dependency-routing
+  counterpart to the path gateway

--- a/book/src/howto/hub.md
+++ b/book/src/howto/hub.md
@@ -1,8 +1,8 @@
 # Run a hub on the public internet
 
-## What you are setting up
+## What You Are Setting Up
 
-The hub is a single Linux (or Windows, or macOS) server sitting on the public internet with an inbound port open. It does not need to be powerful -- a $5/month virtual machine (VM) works fine. It runs `telahubd`, which serves a single endpoint that handles both WebSocket connections from agents and clients and a UDP relay for faster WireGuard transport.
+The hub is a single Linux (or Windows, or macOS) server sitting on the public internet with an inbound port open. It does not need to be powerful; a $5/month virtual machine (VM) works fine. It runs `telahubd`, which serves a single endpoint that handles both WebSocket connections from agents and clients and a UDP relay for faster WireGuard transport.
 
 Every agent and every client in your Tela deployment points at this hub. They connect outbound to it; it brokers the WireGuard sessions between them. It never decrypts tunnel traffic.
 
@@ -18,7 +18,7 @@ The hub's public URL will be `wss://hub.example.com`. Agents use that URL in the
 
 This chapter takes you from "I ran through the [First connection](../getting-started/first-connection.md) walkthrough" to a production-grade deployment with TLS, authentication, and a supervisor (Docker or the OS service manager) that keeps the hub running.
 
-## Hub server: `telahubd`
+## Hub Server: `telahubd`
 
 `telahubd` is the Go-native hub server. Single binary, no runtime dependencies. It serves HTTP, WebSocket relay, and UDP relay on one process.
 
@@ -33,11 +33,11 @@ Prerequisites: Docker Engine and Docker Compose plugin. Any modern Docker instal
 
 This walkthrough deploys the Caddy-fronted production template. Caddy terminates TLS with an auto-issued Let's Encrypt certificate, telahubd runs behind it on the internal Docker network, and the UDP relay port is published directly from the host to telahubd because Caddy is TCP-only. Three templates are maintained in the tela repo under [`deploy/docker/`](https://github.com/paulmooreparks/tela/tree/main/deploy/docker); the "Choosing a different template" section below covers the other two.
 
-#### Step 1. Point DNS
+#### Step 1: Point DNS
 
 Point an `A` record for your hub's hostname (for example `hub.example.com`) at the Docker host's public IP. Let's Encrypt needs this to resolve correctly before it will issue the certificate; if DNS is wrong, the first `docker compose up` appears to hang on the Caddy logs at the ACME challenge step.
 
-#### Step 2. Open firewall ports
+#### Step 2: Open Firewall Ports
 
 Three inbound ports on the Docker host:
 
@@ -47,7 +47,7 @@ Three inbound ports on the Docker host:
 | 443 | TCP | Hub HTTPS and WebSocket. |
 | 41820 | UDP | UDP relay tier. See "The UDP gotcha" below. |
 
-#### Step 3. Pull the compose template
+#### Step 3: Pull the Compose Template
 
 Download the Caddy-fronted production template and its companions into a working directory on the Docker host:
 
@@ -60,7 +60,7 @@ curl -Lo .env.example       "$BASE/.env.example"
 cp .env.example .env
 ```
 
-#### Step 4. Fill in `.env`
+#### Step 4: Fill in `.env`
 
 Edit `.env` and set at least two values:
 
@@ -73,7 +73,7 @@ Optionally also set `TELAHUBD_NAME` (display name shown in TelaVisor and portal 
 
 Do not commit `.env` anywhere public; it contains the owner token.
 
-#### Step 5. Bring it up
+#### Step 5: Bring It Up
 
 ```bash
 docker compose up -d
@@ -89,7 +89,7 @@ curl https://hub.example.com/.well-known/tela
 
 The response is a small JSON document with `hubId` and `protocolVersion` fields. If that is what you see, the hub is live.
 
-#### Step 6. Confirm the owner token
+#### Step 6: Confirm the Owner Token
 
 The token is whatever you put in `.env`. To use it from a workstation:
 
@@ -104,7 +104,7 @@ If you left `TELA_OWNER_TOKEN` blank in `.env`, telahubd auto-generated one on f
 docker exec telahubd telahubd user show-owner -config /data/telahubd.yaml
 ```
 
-#### The UDP gotcha
+#### The UDP Gotcha
 
 Every compose template in this chapter publishes UDP port 41820 with the `/udp` suffix:
 
@@ -117,7 +117,7 @@ Without the suffix, Docker exposes only the TCP side. telahubd does not listen o
 
 If adapting one of the templates and sessions feel slow, `docker port <container-name>` should report `41820/udp`. If it reports `41820/tcp` instead, the suffix was dropped.
 
-#### Choosing a different template
+#### Choosing a Different Template
 
 The Caddy template suits most production deployments. Two alternatives live alongside it:
 
@@ -140,15 +140,15 @@ docker compose pull
 docker compose up -d
 ```
 
-The named volume for `/data` survives container recreation, so config and tokens are preserved. To pin to a specific version instead of tracking `:stable`, edit the `image:` line in the compose file to `ghcr.io/paulmooreparks/telahubd:v0.13.0` or any other published tag.
+The named volume for `/data` survives container recreation, so config and tokens are preserved. To pin to a specific version instead of tracking `:stable`, edit the `image:` line in the compose file to `ghcr.io/paulmooreparks/telahubd:v0.15.0` or any other published tag.
 
-### Install: native binary (alternative)
+### Install: Native Binary (Alternative)
 
 Pre-built binaries for Windows, Linux, and macOS are available on the [GitHub Releases](https://github.com/paulmooreparks/tela/releases) page. Choose this path if Docker is unavailable on the host, if you are running on Windows Server without Docker Desktop, or if you prefer integrating with the host's service manager directly.
 
 The install flow has five steps. Do them in this order. The service install step writes a clean config file; the bootstrap step adds the owner token to that file; the service-start step reads the populated config. Running them out of order either duplicates tokens or leaves you starting the hub against a blank config.
 
-#### Step 1. Pick a deployment model
+#### Step 1: Pick a Deployment Model
 
 | Model | `telahubd` port | Public port | TLS | Notes |
 |-------|-----------------|-------------|-----|-------|
@@ -160,7 +160,7 @@ The install flow has five steps. Do them in this order. The service install step
 
 `telahubd` binds its port on all interfaces, so for any of the proxy models above you must block external access to that port at the firewall. Only the reverse proxy should be able to reach it, over localhost. Proxy setup details live in [Publish with TLS](#publish-with-tls-recommended) further down. Decide the port now because `service install` in step 3 writes that port into the config.
 
-#### Step 2. Download the binary
+#### Step 2: Download the Binary
 
 Replace `amd64` with `arm64` for ARM hardware (Raspberry Pi, AWS Graviton, Apple Silicon). On macOS Apple Silicon use `darwin-arm64`; on Intel Macs use `darwin-amd64`.
 
@@ -190,7 +190,7 @@ Invoke-WebRequest -Uri https://github.com/paulmooreparks/tela/releases/latest/do
 
 Add `C:\Program Files\Tela` to the system `PATH` so later commands resolve the binary. The service install step below records the absolute path in the Windows service definition regardless, so `PATH` is only needed for interactive use.
 
-#### Step 3. Install the OS service
+#### Step 3: Install the OS Service
 
 This writes a fresh YAML config to the platform-standard location and registers the service with the OS. No tokens are written yet.
 
@@ -221,7 +221,7 @@ sudo telahubd service install -config /etc/tela/telahubd.yaml
 
 That keeps the existing tokens and just registers the OS service. If you took this path, skip step 4 (the tokens are already there) and continue to step 5. To change the port or hub name after the fact, stop the service, edit the YAML file directly, and start it again.
 
-#### Step 4. Bootstrap the owner token
+#### Step 4: Bootstrap the Owner Token
 
 This adds an `owner` identity to the config file from step 3 and prints the token once. Save it immediately. You use this token to register agents, run `tela admin`, and sign into TelaVisor as an administrator.
 
@@ -239,7 +239,7 @@ sudo telahubd user bootstrap
 
 The token will not be shown again. Store it in a password manager. For day-to-day agent and client connections, create lower-privilege tokens with `tela admin tokens add` (see [Authentication](#authentication) below).
 
-#### Step 5. Start the service
+#### Step 5: Start the Service
 
 **Linux / macOS:**
 
@@ -266,7 +266,7 @@ curl http://localhost:8080/api/status   # (or port 80 for direct/Cloudflare depl
 
 You should see a JSON response with `hub`, `version`, and connection counts. If you picked a proxy model, continue to [Publish with TLS](#publish-with-tls-recommended) to configure it. If you picked direct, the hub is already reachable on port 80 and you can skip ahead to [Register with a hub directory](#register-with-a-hub-directory).
 
-### Running in the foreground (dev only)
+### Running in the Foreground (Dev Only)
 
 For local testing, you can skip the service install and run `telahubd` directly from a terminal. It looks for a config in this order:
 
@@ -283,13 +283,13 @@ telahubd -config my.yaml   # explicit config path
 
 Do not start the service and run `telahubd` in the foreground at the same time. Both try to bind the same listening port, and the second one will fail.
 
-### Build from source
+### Build from Source
 
 ```bash
 go build -o telahubd ./cmd/telahubd
 ```
 
-### Environment variables
+### Environment Variables
 
 Environment variables override the YAML config file at runtime, useful for container deployments or quick experiments without editing `/etc/tela/telahubd.yaml`.
 
@@ -327,7 +327,7 @@ The `user bootstrap` step is one way to install the owner token. Two alternative
 - **Hand-author the YAML file.** See [Appendix B: Configuration file reference](../guide/configuration.md) for the shape. Useful when the token is managed by a secrets provisioning tool.
 - **`TELA_OWNER_TOKEN` env var (foreground only).** When the variable is set and the config has no tokens, `telahubd` writes it into the config on first startup. The env var is only visible to the running process, so this works for `telahubd` launched directly in a shell (or a container with the variable set at runtime). Services launched by systemd, launchd, or Windows SCM do not inherit shell environment variables, so the env-var path does not apply to `service start`; use `user bootstrap` there.
 
-### Managing tokens remotely with `tela admin`
+### Managing Tokens Remotely with `tela admin`
 
 Once the owner token exists, manage everything from any workstation:
 
@@ -357,7 +357,7 @@ tela admin tokens remove alice -hub wss://your-hub.example.com -token <owner-tok
 
 All changes take effect immediately (hot-reload). No hub restart required.
 
-### Managing portals remotely with `tela admin`
+### Managing Portals Remotely with `tela admin`
 
 Register your hub with a portal directory (like Awan Saya) from any workstation:
 
@@ -373,7 +373,7 @@ tela admin portals list -hub wss://your-hub.example.com -token <owner-token>
 tela admin portals remove awansaya -hub wss://your-hub.example.com -token <owner-token>
 ```
 
-### Using `telad` with auth
+### Using `telad` with Auth
 
 When the hub has auth enabled, agents must present a valid token. Do not use
 the owner token here. Create a dedicated agent identity with `tela admin tokens
@@ -396,7 +396,7 @@ telad -config telad.yaml
 
 Or with a flag: `telad -hub wss://... -machine barn -ports "22,3389" -token <agent-token>`
 
-### Using `tela` (client) with auth
+### Using `tela` (Client) with Auth
 
 Client connections use a user-role token with connect permission on the target
 machine. Do not use the owner token for routine client connections. Create a
@@ -411,7 +411,7 @@ export TELA_TOKEN=<user-token>
 tela connect -machine barn
 ```
 
-## What must be reachable
+## What Must Be Reachable
 
 | Port | Protocol | Required | Purpose |
 |------|----------|----------|---------|
@@ -421,7 +421,7 @@ tela connect -machine barn
 
 \* Port 80 is required by Caddy for automatic certificate issuance. If you use DNS-01 challenges or bring your own certificate, you can skip it.
 
-### Open firewall ports (cloud VMs)
+### Open Firewall Ports (Cloud VMs)
 
 Cloud VMs block inbound traffic by default. You must explicitly allow the ports above in your provider's firewall/security group.
 
@@ -466,7 +466,7 @@ Then add the `tela-hub` network tag to your VM instance.
 
 **Self-hosted / bare metal:** Ensure `ufw`, `iptables`, or your router forwards these ports to the hub machine.
 
-## Publish with TLS (recommended)
+## Publish with TLS (Recommended)
 
 > **Docker install**: the Docker walkthrough above already configured Caddy and Let's Encrypt via `docker-compose.caddy.yml`. Skip to [Register with a hub directory](#register-with-a-hub-directory) below. The subsections here apply to native installs that need a separately-managed reverse proxy.
 
@@ -621,7 +621,7 @@ sudo certbot --apache -d myhub.example.com
 
 On RHEL / Fedora, replace `a2enmod`/`a2ensite` with editing `/etc/httpd/conf.modules.d/` and `/etc/httpd/conf.d/`, and use `systemctl reload httpd`.
 
-### Alternative: Cloudflare Tunnel (zero inbound ports)
+### Alternative: Cloudflare Tunnel (Zero Inbound Ports)
 
 If you do not want to expose any inbound ports, Cloudflare Tunnel makes an outbound connection to Cloudflare's edge, which terminates TLS and proxies traffic back to your hub. With Cloudflare Tunnel `telahubd` can stay on port 80 (the direct-deployment default from step 3 of the install flow), so skip the port-8080 change above.
 
@@ -643,11 +643,11 @@ cloudflared tunnel run my-hub
 
 Cloudflare Tunnel is TCP-only, so the UDP relay (port 41820) cannot pass through it and sessions will use WebSocket transport instead.
 
-## Register with a hub directory
+## Register with a Hub Directory
 
 Once the hub is reachable, add it to a hub directory (such as Awan Saya) so users and the CLI can find it by short name.
 
-### Option A: CLI (recommended)
+### Option A: CLI (Recommended)
 
 From any workstation with the hub's owner token:
 
@@ -660,12 +660,12 @@ tela admin portals add awansaya \
 
 The hub will register itself with the portal, exchange viewer tokens for status proxying, and store a scoped sync token so future viewer-token updates happen automatically.
 
-### Option B: Portal dashboard
+### Option B: Portal Dashboard
 
 1. Open the portal dashboard and click **Add Hub**.
 2. Enter a short name (e.g., `myhub`), the hub's public URL (e.g., `https://your-hub.example.com`), and optionally a **viewer token** (so the portal can proxy hub status server-side).
 
-### After registration
+### After Registration
 
 The hub will appear in the portal dashboard and be resolvable by the CLI:
 
@@ -675,7 +675,7 @@ tela machines -hub myhub -token <your-token>
 tela connect -hub myhub -machine mybox -token <your-token>
 ```
 
-## Verify from outside
+## Verify from Outside
 
 From a machine on the Internet (or at least outside your LAN), verify:
 

--- a/book/src/howto/networking.md
+++ b/book/src/howto/networking.md
@@ -1,122 +1,166 @@
-# Networking caveats
+# Networking Caveats
 
-## When to read this
+Tela is designed to work through firewalls and Network Address Translation
+(NAT) without special configuration on the agent or client side. The hub is
+the only component that needs an inbound port. Both agents and clients
+connect to the hub outbound, over a standard HTTPS or WebSocket connection.
+In most environments that is all you need to know.
 
-If `telad` is running and the hub is reachable but connections are not working, or if you are deploying Tela into a network environment with strict firewall rules, proxies, or unusual topology, this chapter is for you.
+Read this chapter when the defaults do not hold: `telad` is running and the
+hub is reachable but connections are not working, or you are deploying Tela
+into a network with strict firewall rules, proxies, or unusual topology.
+The second half answers the topology and addressing questions that come up
+when evaluating Tela against mesh VPNs.
 
-Tela is designed to work through firewalls and Network Address Translation (NAT) without special configuration on the agent or client side. The hub is the only component that needs an inbound port. Both agents and clients connect to the hub outbound, over a standard HTTPS or WebSocket connection. In most environments that is all you need to know.
+## Quick Matrix
 
-The sections below make the networking requirements explicit for cases where the default assumptions do not hold: restricted outbound firewall rules, proxy environments, UDP relay configuration, and questions about how Tela's internal addressing works alongside your existing network.
-
-## Quick matrix
-
-| Component | Needs inbound from Internet | Needs outbound | Default ports / protocols |
+| Component | Needs Inbound from Internet | Needs Outbound | Default Ports and Protocols |
 |----------|------------------------------|---------------|---------------------------|
-| Hub (`telahubd`) | Yes | No (special) | Public: TCP 443 for HTTPS+WebSockets; Optional: UDP 41820 for UDP relay. The hub listens on `TELAHUBD_PORT` (default `80`) and `TELAHUBD_UDP_PORT` (default `41820`). |
-| Daemon (`telad`) | No | Yes | Outbound WebSocket to hub (`ws://` / `wss://`); optional outbound UDP to hub `TELAHUBD_UDP_PORT` |
-| Client (`tela`) | No | Yes | Outbound WebSocket to hub (`ws://` / `wss://`); optional outbound UDP to hub `TELAHUBD_UDP_PORT` |
-| Portal (browser UI) | n/a | Yes | Browser fetches `https://<hub>/api/status` and `https://<hub>/api/history` (cross-origin) |
+| Hub (`telahubd`) | Yes | No | TCP for HTTP and WebSocket (`TELAHUBD_PORT`, default `80`, typically published on 443 via a reverse proxy); optional UDP relay (`TELAHUBD_UDP_PORT`, default `41820`) |
+| Agent (`telad`) | No | Yes | Outbound WebSocket to the hub (`ws://` or `wss://`); optional outbound UDP to the hub's UDP port |
+| Client (`tela`) | No | Yes | Outbound WebSocket to the hub; optional outbound UDP to the hub's UDP port |
+| Portal (browser UI) | n/a | Yes | Browser fetches `https://<hub>/api/status` and `https://<hub>/api/history` cross-origin |
 
-## Hub requirements
+## Hub Requirements
 
-The hub is the only component that typically needs **inbound** connectivity.
+The hub is the only component that needs inbound connectivity.
 
-Minimum:
+Minimum: inbound TCP for HTTPS and WebSockets. The hub serves HTTP and
+WebSocket on a single port (`TELAHUBD_PORT`, default `80`) and is commonly
+published on 443 by a reverse proxy. The reverse proxy must forward
+`Upgrade` and `Connection` headers, or WebSocket upgrades fail and nothing
+can connect.
 
-- Inbound TCP for **HTTPS + WebSockets**.
-  - The hub serves HTTPS + WebSockets on a single public origin (typically TCP 443).
-  - Implementation note: the hub serves HTTP+WS on a single port (`TELAHUBD_PORT`, default `80`) and is commonly published on 443 via a reverse proxy.
-  - The reverse proxy must forward `Upgrade` / `Connection` headers to support WebSocket upgrades.
+Optional, for performance: inbound UDP on `TELAHUBD_UDP_PORT` (default
+`41820`) to enable the hub's UDP relay. If this port is not reachable (for
+example, the hub is only exposed through a TCP-only tunnel), sessions still
+work over WebSockets; they are just slower. If the hub's domain resolves to
+a proxy (for example, Cloudflare), set `TELAHUBD_UDP_HOST` to an address
+that resolves directly to the hub and forward UDP on your router. Without
+this, clients send UDP to the proxy and it is silently dropped.
 
-Optional (performance / transport):
+For a browser-based portal to display hub cards and metrics, the hub must
+expose `GET /api/status` and `GET /api/history`. Cross-origin portal
+fetches require Cross-Origin Resource Sharing (CORS); the hub replies with
+`Access-Control-Allow-Origin: *` for these endpoints.
 
-- Inbound UDP `TELAHUBD_UDP_PORT` (default `41820`) to enable the hub's UDP relay.
-  - If this is not reachable (for example, you only expose the hub via a TCP-only tunnel), sessions still work via WebSockets; they may be slower.
-  - If the hub's domain resolves to a proxy (for example, Cloudflare), set `TELAHUBD_UDP_HOST` to the real public IP or a Domain Name System (DNS) name that resolves directly, and forward UDP on your router. Without this, clients send UDP to the proxy and it is silently dropped.
+## Agent Requirements
 
-Portal visibility:
+`telad` works in outbound-only environments, but it has two reachability
+needs:
 
-- For Awan Saya (or any browser-based portal) to display hub cards and metrics, the hub must expose:
-  - `GET /api/status` (and/or `/status`)
-  - `GET /api/history`
-- Cross-origin portal fetches require Cross-Origin Resource Sharing (CORS). The hub replies with `Access-Control-Allow-Origin: *` for these endpoints.
+1. **Outbound to the hub.** It must be able to establish a long-lived
+   WebSocket connection to the hub URL in `telad.yaml`.
+2. **Reachability to the services it exposes.** In the endpoint pattern
+   (agent on the target host), services are usually on `localhost`. In the
+   gateway pattern (agent on a different host), the agent host must be able
+   to reach the target's service ports; `target: host.docker.internal`, for
+   example, bridges from a containerized agent to services on the Docker
+   host.
 
-## Daemon (`telad`) requirements
+If the UDP relay is enabled on the hub, `telad` may also send UDP to the
+hub's UDP port.
 
-`telad` is designed to work in outbound-only environments, but it has two key reachability needs:
+## Client Requirements
 
-1) **Outbound to the hub**
+The client needs an outbound WebSocket to the hub, plus optional outbound
+UDP when the UDP relay is enabled.
 
-- Must be able to establish a long-lived WebSocket connection to the hub URL in `telad.yaml` (example: `hub: ws://hub` or `hub: wss://hub.example.com`).
+Locally, the client binds a loopback listener on `127.0.0.1` at each
+service's configured local port so local applications (SSH, Remote Desktop
+Protocol (RDP) clients, database tools) can connect. If a port is taken,
+the client tries the port plus 10000, then plus 10001, and so on until a
+free port is found. The bound port is shown in the `tela connect` output
+and in TelaVisor's Status tab. This listener is local-only, not inbound
+from the internet.
 
-2) **Reachability to the services it exposes**
+## Topology and Addressing
 
-- Endpoint pattern (daemon runs on the target host): services are usually on `localhost`.
-- Gateway/bridge pattern (daemon runs somewhere else): the daemon host must be able to reach the target's service ports.
-  - Example: `target: host.docker.internal` bridges from a containerized daemon to services running on the Docker host.
+These questions come up often from people evaluating Tela against mesh
+Virtual Private Networks (VPNs) or traditional VPNs. The short answers are
+here; the [Design Rationale](../architecture/design.md) section has the
+longer rationale.
 
-Optional:
+### Does Tela Create an L3 Network?
 
-- If UDP relay is enabled on the hub, `telad` may also send UDP to the hub's `TELAHUBD_UDP_PORT`.
+Not in the sense that a mesh VPN does. Tela creates per-session
+point-to-point WireGuard tunnels. Each session gets its own /24 from the
+`10.77.0.0/16` range: `10.77.{idx}.1` on the agent side, `10.77.{idx}.2` on
+the client side. The session index is assigned by the hub, increments
+monotonically per machine, and maxes out at 254 (one machine can serve up
+to 254 simultaneous client sessions).
 
-## Client (`tela`) requirements
+Critically, these addresses exist only inside gVisor's userspace network
+stack. They never appear as host interfaces, routing table entries, or
+Address Resolution Protocol (ARP) entries on either machine.
 
-- Outbound WebSocket to the hub.
-- Optional outbound UDP to hub `TELAHUBD_UDP_PORT` when UDP relay is enabled.
+### Does It Clash with My Existing IP Addressing?
 
-Local binding:
+No. Because Tela runs WireGuard in userspace through gVisor, the
+`10.77.x.x` session addresses are internal to the process. The host
+operating system sees no new interfaces, no new routes, and no new
+neighbors. A machine with a LAN IP of `10.77.5.100` has no conflict with a
+Tela session using `10.77.5.0/24`.
 
-- The client binds a loopback listener on `127.0.0.1` at the service's configured local port so local apps (SSH, Remote Desktop Protocol (RDP), and others) can connect. If that port is taken, the client tries `localport + 10000`, `localport + 10001`, and so on until a free port is found. The bound port is shown in the `tela connect` output and in TelaVisor's Status tab.
-  - This is local-only, not inbound from the Internet.
+### How Do I Find and Reach Services? Is There DNS?
 
-## Topology and addressing
+You do not use tunnel-internal IP addresses or DNS to reach services
+through Tela. The workflow is:
 
-These questions come up often from people evaluating Tela against mesh Virtual Private Networks (VPNs) or traditional VPNs. The short answers are here; the [Design Rationale](../architecture/design.md) section has the longer rationale.
+1. You tell `tela` (or TelaVisor) which machine on which hub you want to
+   connect to, and which services on that machine you want.
+2. `tela` binds each service at `localhost:PORT` on your machine: the
+   configured local port, the service's native port, or a fallback port
+   starting at the port plus 10000 when the first choice is in use.
+3. You point your SSH client, browser, or database tool at
+   `localhost:PORT`.
 
-### Does Tela create an L3 network?
+`tela connect` and `tela status` print the bound address and port for each
+service. TelaVisor shows them in the Status tab. To pin a service to a
+specific local port across reconnects, set `local:` on that service in your
+profile. To get name-based access (`ssh barn.tela`), see the
+[DNS Names](../guide/profiles.md#dns-names) section of the Connection
+Profiles chapter.
 
-Not in the sense that a mesh VPN does. Tela creates per-session point-to-point WireGuard tunnels. Each session gets its own /24 from the `10.77.0.0/16` range: `10.77.{idx}.1` on the agent side, `10.77.{idx}.2` on the client side. The session index is assigned by the hub, increments monotonically per machine, and maxes out at 254 (one machine can serve up to 254 simultaneous client sessions).
+### Can I Ping Through the Tunnel?
 
-Critically, these addresses exist only inside gVisor's userspace network stack. They never appear as host interfaces, routing table entries, or Address Resolution Protocol (ARP) entries on either machine. There is no risk of collision with your LAN's `10.77.x.x` subnet because Tela's addresses are not visible to the host network at all.
+No. Tela tunnels TCP only. Internet Control Message Protocol (ICMP), which
+carries `ping` and `traceroute`, does not travel through the tunnel. This
+also means no UDP services: if your application uses UDP (SIP, QUIC, game
+protocols), it will not work through a Tela tunnel today.
 
-### Does it clash with my existing IP addressing?
+### Can Agents Talk to Each Other?
 
-No. Because Tela runs WireGuard in userspace through gVisor, the `10.77.x.x` session addresses are internal to the process. The host operating system sees no new interfaces, no new routes, and no new neighbors. A machine with a LAN IP of `10.77.5.100` has no conflict with a Tela session using `10.77.5.0/24`.
+Not directly. Tela does not route between agents. To get data from machine
+A to machine B, you need a client on the path: `tela` connects to A, gets
+the data, and separately connects to B to send it. There is no
+agent-to-agent tunnel without a client in the middle. The hub-to-hub relay
+gateway addresses hub bridging, not agent-to-agent routing.
 
-### How do I find and reach services? Is there DNS?
+### Does Tela Support IPv6?
 
-You do not use tunnel-internal IP addresses or DNS to reach services through Tela. The workflow is:
+The WireGuard session addressing is IPv4 (`10.77.x.x`). The control channel
+between agents, clients, and the hub (WebSocket or UDP relay) works over
+whatever IP version the hub is reachable on. End-to-end IPv6 service
+tunneling is not currently supported; the gVisor netstack inside the agent
+and client uses IPv4 for the tunnel. IPv6 is on the long-term list but is
+not a 1.0 requirement.
 
-1. You tell `tela` (or TelaVisor) which machine on which hub you want to connect to, and which services on that machine you want.
-2. `tela` binds each service at `localhost:PORT` on your machine. The port is the configured local port for that service, or the service's native port if no local port is set. If the port is already in use, the client tries successive fallback ports starting at `localport + 10000`.
-3. You point your SSH client, browser, or database tool at `localhost:PORT`.
+### How Many Clients Can Connect to One Agent Simultaneously?
 
-`tela connect` and `tela status` print the bound address and port for each service. TelaVisor shows them in the Status tab. To pin a service to a specific local port across reconnects, set `local:` on that service in your profile.
+Up to 254. The session index is an 8-bit counter; session index 0 is
+reserved, leaving 1 through 254 for active sessions. A 255th session is
+rejected by the hub. In practice, the bottleneck is usually the agent
+machine's bandwidth or the services behind it, not the session limit.
 
-### Can I ping through the tunnel?
+## Checklist
 
-No. Tela tunnels TCP only. Internet Control Message Protocol (ICMP), which carries `ping` and `traceroute`, does not travel through the tunnel. This also means no UDP services. If your application uses UDP (SIP, QUIC, game protocols), it will not work through a Tela tunnel today.
+When something cannot connect, check these in order:
 
-### Can agents talk to each other?
-
-Not directly. Tela does not route between agents. To get data from machine A to machine B, you need a client on the path: `tela` connects to A, gets the data, and separately connects to B to send it. There is no agent-to-agent tunnel without a client in the middle. The hub-to-hub relay gateway planned for 1.0 addresses hub federation, not agent-to-agent routing.
-
-### Does Tela support IPv6?
-
-The WireGuard session addressing is IPv4 (`10.77.x.x`). The control channel between agents, clients, and the hub (WebSocket or UDP relay) works over whatever IP version the hub is reachable on. End-to-end IPv6 service tunneling is not currently supported; the gVisor netstack inside the agent and client uses IPv4 for the tunnel. IPv6 is on the long-term list but is not a 1.0 requirement.
-
-### How many clients can connect to one agent simultaneously?
-
-Up to 254. The session index is an 8-bit counter; session index 0 is reserved, leaving 1-254 for active sessions. Attempting a 255th session is rejected by the hub. In practice, the bottleneck is usually the agent machine's bandwidth or the services behind it, not the session limit.
-
----
-
-## Checklist (copy/paste)
-
-When something "can't connect", check these in order:
-
-- Hub is reachable on TCP 443 (or wherever you publish `TELAHUBD_PORT`).
-- Reverse proxy supports WebSockets.
-- Daemon can reach the hub URL from where it runs.
-- Daemon can reach its `target` host and the service ports behind it.
-- If you expect UDP relay: hub UDP port reachable + outbound UDP allowed from client/daemon.
+1. The hub is reachable on TCP 443 (or wherever you publish
+   `TELAHUBD_PORT`).
+2. The reverse proxy forwards WebSocket upgrades.
+3. The agent can reach the hub URL from where it runs.
+4. The agent can reach its `target` host and the service ports behind it.
+5. If you expect the UDP relay: the hub's UDP port is reachable inbound,
+   and outbound UDP is allowed from both the client and the agent.

--- a/book/src/howto/services.md
+++ b/book/src/howto/services.md
@@ -1,127 +1,98 @@
-# Run Tela as an OS service
+# Run Tela as an OS Service
 
-## What you are setting up
+When you run `telad` or `telahubd` from a terminal, they stop when the
+terminal closes. That is fine for testing but not for production. A server
+that reboots at 3 AM should bring its tunnel back up automatically, without
+anyone logging in and running a command.
 
-When you run `telad` or `telahubd` from a terminal, they stop when the terminal closes. That is fine for testing but not for production. A server that reboots at 3 AM should bring its tunnel back up automatically, without anyone logging in and running a command.
+This chapter covers installing `telad` and `telahubd` as native OS services
+so they start at boot, restart on failure, and survive logouts. The
+mechanism is the platform's own service manager: Windows Service Control
+Manager (SCM), systemd on Linux, launchd on macOS. Standard service
+management tools (`sc`, `systemctl`, `launchctl`) all work on these
+processes.
 
-This chapter covers installing `telad` and `telahubd` as native OS services so they start at boot, restart on failure, and survive logouts. The mechanism is the platform's own service manager -- Windows Service Control Manager (SCM), systemd on Linux, launchd on macOS -- which means standard service management tools (`sc`, `systemctl`, `launchctl`) all work on these processes.
+The `tela` client also supports installation as a service (for an always-on
+tunnel that starts at boot) and user-level autostart (starts at login).
+Both are most conveniently set up from TelaVisor's Client Settings tab; the
+CLI equivalent is `tela service install -config <profile.yaml>`.
 
-By the end of this chapter, `telad` (or `telahubd`, or both) will:
+## How It Works
 
-- Start automatically when the machine boots, before any user logs in
-- Restart automatically if the process crashes
-- Accept `start`, `stop`, `restart`, and `status` commands from the OS service manager
-- Persist its configuration in the service metadata so no external config file needs to be present at startup
+Each binary stores its runtime configuration in the service metadata
+(Windows registry, systemd unit, launchd plist). Configuration can be
+loaded from a YAML file or embedded inline from command-line flags. When
+you run `service install`, the binary encodes the configuration and
+registers it with the OS service manager. The service itself just runs
+`<binary> service run`, which loads the configuration from metadata, or
+falls back to a YAML file if present.
 
-The `tela` client also supports user-level autostart (starts at login, not at boot) for cases where you want a persistent client tunnel tied to your login session rather than to the machine. That is covered at the end of the chapter.
-
-## How it works
-
-Each binary stores its runtime configuration in the service metadata (Windows registry, systemd config, launchd plist). This eliminates filesystem permission issues and keeps everything in one place.
-
-Configuration can be:
-1. **Loaded from a YAML file** (for structured multi-machine setups)
-2. **Embedded inline** (for simple single-machine deployments)
-
-When you run `service install`, the binary encodes the configuration and registers it with the OS service manager. The service just runs `<binary> service run`, which loads the configuration from metadata (or falls back to a YAML file if present).
-
-**To reconfigure:**
-- Edit the YAML config file (if one exists) and run `service restart`, or
-- Reinstall with new parameters using `service install`
-
----
+To reconfigure a service, edit the YAML config file (if one exists) and run
+`service restart`, or reinstall with new parameters using
+`service install`.
 
 ## telad
 
-### Install
+Two installation modes are available. Both require elevation (an
+Administrator prompt on Windows, `sudo` on Linux and macOS).
 
-Two installation modes are available:
-
-**Mode 1: From a config file (recommended for complex setups)**
+**Mode 1: from a config file**, for structured multi-machine setups:
 
 ```bash
-# Windows: run from an elevated (Administrator) prompt.
-# Linux/macOS: use sudo.
-
 telad service install -config telad.yaml
 ```
 
-The config file is validated, embedded in service metadata, and a reference copy is retained on disk at (for example) `C:\ProgramData\Tela\telad.yaml` or `/etc/tela/telad.yaml`.
+The config file is validated, embedded in the service metadata, and a
+reference copy is retained on disk at the platform-standard path
+(`/etc/tela/telad.yaml` or `%ProgramData%\Tela\telad.yaml`). Make sure the
+file includes the hub URL, token, and machine definitions before
+installing; see [Run an Agent](telad.md) for the config format and
+authentication setup.
 
-Make sure your `telad.yaml` includes the hub URL, auth token, and machine definitions before installing. See [Run an agent](telad.md) for the full config format and authentication setup.
-
-**Mode 2: Inline configuration (recommended for simple setups)**
-
-```bash
-telad service install -hub ws://your-hub:8080 -machine barn -ports "22:SSH,3389:RDP"
-```
-
-Configuration is passed as command-line flags and stored inline. No external file is needed. Ideal for single-machine deployments without additional setup.
-
-### Config file format
-
-```yaml
-# telad.yaml - register machines with the hub.
-hub: wss://tela.example.com
-token: my-secret-token        # optional auth token
-
-machines:
-  - name: workstation
-    hostname: workstation
-    os: windows
-    services:
-      - port: 3389
-        proto: tcp
-        name: RDP
-        description: Remote Desktop
-      - port: 22
-        proto: tcp
-        name: SSH
-    target: 127.0.0.1          # where to forward traffic (default)
-```
-
-### Manage
+**Mode 2: inline configuration**, for simple single-machine deployments:
 
 ```bash
-telad service start       # Start the service
-telad service stop        # Stop the service
-telad service restart     # Stop + start (after editing config)
-telad service status      # Show current state
-telad service uninstall   # Remove the service and config
+telad service install -hub wss://hub.example.com -machine barn -ports "22:SSH,3389:RDP"
 ```
 
----
+Configuration is passed as command-line flags and stored inline in the
+service metadata. No external file is needed.
+
+Manage the service with the same subcommand family:
+
+```bash
+telad service start
+telad service stop
+telad service restart     # after editing the config
+telad service status
+telad service uninstall   # removes the service and its stored config
+```
 
 ## telahubd
 
-### Install
-
-You can either provide an existing config file or let the installer generate one from flags:
+Provide an existing config file or let the installer generate one from
+flags:
 
 ```bash
 # Option 1: from a config file
 telahubd service install -config telahubd.yaml
 
 # Option 2: generate from flags
-telahubd service install -name myhub -port 80 -udp-port 41820
+telahubd service install -name myhub -port 8080 -udp-port 41820
 ```
 
-### Config file format
+Authentication (tokens, access control lists) is managed separately, via
+`telahubd user bootstrap` for the first owner token and `tela admin`
+commands for subsequent identities. You do not need to edit auth
+configuration in the YAML file manually. See
+[Run a Hub on the Public Internet](hub.md) for the full deployment
+walkthrough, including the ordering between `service install` and
+`user bootstrap`.
 
-```yaml
-# telahubd.yaml - hub server configuration.
-port: 80            # HTTP + WebSocket listen port
-udpPort: 41820      # UDP relay port
-name: "My Hub"      # Display name (optional)
-```
+Environment variables (`TELAHUBD_PORT`, `TELAHUBD_UDP_PORT`,
+`TELAHUBD_NAME`) always override the config file.
 
-> Authentication (tokens, access control lists) is managed separately via `telahubd user bootstrap` (for the first owner token) and `tela admin` commands (for subsequent identities). You do not need to edit auth configuration in the YAML file manually. See [Run a hub on the public internet](hub.md) for details.
-
-> **Bootstrap ordering:** Run `telahubd user bootstrap` **before** `telahubd service install` if you want the installed config to already contain auth tokens. If you install the service first and then bootstrap, the bootstrap writes directly to the system config path (`/etc/tela/telahubd.yaml` or `%ProgramData%\Tela\telahubd.yaml`).
-
-> Environment variables (`TELAHUBD_PORT`, `TELAHUBD_UDP_PORT`, `TELAHUBD_NAME`) always override the config file.
-
-### Manage
+Manage the service:
 
 ```bash
 telahubd service start
@@ -131,34 +102,37 @@ telahubd service status
 telahubd service uninstall
 ```
 
----
-
-## Platform details
+## Platform Details
 
 ### Windows
 
-The service is registered with the Service Control Manager (SCM) using auto-start and automatic restart on failure (5 s, 5 s, 30 s delays, reset after 24 h). Administrator privileges are required for all operations except `service status`.
+The service is registered with the Service Control Manager using auto-start
+and automatic restart on failure (5 s, 5 s, 30 s delays, reset after 24 h).
+Administrator privileges are required for all operations except
+`service status`.
 
 ### Linux (systemd)
 
-A unit file is written to `/etc/systemd/system/<name>.service`, enabled on boot, and set to restart on failure. Root is required for install/start/stop.
+A unit file is written to `/etc/systemd/system/<name>.service`, enabled on
+boot, and set to restart on failure. Root is required for install, start,
+and stop.
 
 ### macOS (launchd)
 
-A plist is written to `/Library/LaunchDaemons/com.tela.<name>.plist` with `RunAtLoad` and `KeepAlive` enabled. Root is required.
-
----
+A plist is written to `/Library/LaunchDaemons/com.tela.<name>.plist` with
+`RunAtLoad` and `KeepAlive` enabled. Root is required.
 
 ## Troubleshooting
 
-| Symptom | Likely cause |
+| Symptom | Likely Cause |
 |---|---|
-| "administrator privileges required" | Run from an elevated prompt / use `sudo` |
-| "service __ is already installed" | Run `service uninstall` first |
-| Service starts but exits immediately | Check the YAML config for errors; review logs |
+| "administrator privileges required" | Run from an elevated prompt or use `sudo` |
+| "service is already installed" | Run `service uninstall` first |
+| Service starts but exits immediately | Check the YAML config for errors; review the logs |
 | Config changes not taking effect | Run `service restart` after editing |
 
-**Log locations:**
-- **Windows:** Event Viewer → Application
+Log locations:
+
+- **Windows:** Event Viewer, under Application
 - **Linux:** `journalctl -u telad` or `journalctl -u telahubd`
 - **macOS:** `/var/log/telad.log` or `/var/log/telahubd.log`

--- a/book/src/howto/telad.md
+++ b/book/src/howto/telad.md
@@ -1,212 +1,195 @@
-# Run an agent
+# Run an Agent
 
-## What you are setting up
+The agent (`telad`) is the daemon that runs on, or near, the machine you
+want to reach. It makes an outbound connection to the hub, registers the
+machine under a name you choose, and tells the hub which TCP ports to
+expose to connecting clients. No inbound ports are required on the agent
+machine.
 
-The agent (`telad`) is the daemon that runs on -- or near -- the machine you want to reach. It makes an outbound connection to the hub, registers the machine under a name you choose, and tells the hub which TCP ports to expose to connecting clients. No inbound ports are required on the agent machine.
+Picture a Linux server named `barn` sitting on a private network behind a
+router. It has SSH on port 22 and a PostgreSQL database on port 5432.
+Without Tela, reaching those services from the outside requires a VPN, a
+bastion host, or an open inbound port. With Tela, you install `telad` on
+`barn`, point it at your hub, and declare which ports to expose. From that
+moment, any client with the right token can connect to `barn`'s services
+through the hub, from anywhere, without any firewall changes on `barn`'s
+network.
 
-Picture a Linux server named `barn` sitting on a private network behind a router. It has SSH on port 22 and a Postgres database on port 5432. Without Tela, reaching those services from the outside requires a VPN, a bastion host, or an open inbound port. With Tela, you install `telad` on `barn`, point it at your hub, and declare which ports to expose. From that moment, any client with the right token can connect to `barn`'s services through the hub -- from anywhere, without any firewall changes on `barn`'s network.
+This chapter takes you through configuring the agent, getting it a properly
+scoped token, and choosing between the two deployment patterns. Running the
+agent as a managed OS service is covered in
+[Run Tela as an OS Service](services.md).
 
-By the end of this chapter you will have:
+## Two Deployment Patterns
 
-- `telad` installed and configured with a `telad.yaml`
-- A machine registered with the hub under a name like `barn`
-- One or more services exposed through the tunnel (SSH, RDP, or any TCP service)
-- An agent token that scopes the agent's access to just what it needs
-- `telad` running as a managed OS service so it survives reboots
+**Endpoint agent (the common case).** `telad` runs on the machine that
+hosts the services, and the services are reachable on `localhost`. The
+agent needs outbound connectivity to the hub (`ws://` or `wss://`) and
+nothing else.
 
-The chapter covers two deployment patterns: the endpoint pattern (agent runs directly on the target machine, which is the most common case) and the gateway pattern (agent runs on a separate machine and forwards to LAN-reachable targets, which is useful for containers, Docker hosts, or machines you cannot install software on).
+**Gateway, or bridge, agent.** `telad` runs on a separate machine (a VM, a
+container, a small box at the site) and forwards to services on other
+machines it can reach over the local network. Each machine entry in the
+config carries a `target:` address pointing at the real host. Use this when
+you cannot install software on the target machine, or when one agent should
+front many devices. The gateway host must be able to reach each target on
+the declared service ports, which makes it the most common failure point;
+verify that reachability first when troubleshooting.
 
-## Two deployment patterns
+A common Docker variant is bridging from an agent container to services
+running on the Docker host, using `target: host.docker.internal`.
 
-### 1) Endpoint daemon (direct)
+## Configuration
 
-- `telad` runs on the machine that actually hosts the services.
-- Services are usually reachable on `localhost`.
-
-Connectivity:
-
-- `telad` needs **outbound** connectivity to the hub (`ws://` or `wss://`).
-- No inbound Internet ports required on the endpoint.
-
-### 2) Gateway / bridge daemon
-
-- `telad` runs on a gateway (VM/container) and "points at" a target machine.
-- Services must be reachable from the gateway.
-
-Connectivity:
-
-- `telad` needs **outbound** connectivity to the hub.
-- The gateway host must be able to reach the target host on the service ports.
-
-A common Docker variant is bridging from a daemon container to services running on the Docker host:
-
-- `target: host.docker.internal`
-
-## Config basics
-
-Example `telad.yaml`:
+A minimal endpoint-agent `telad.yaml`:
 
 ```yaml
-hub: wss://your-hub.example.com
+hub: wss://hub.example.com
 token: "<agent-token>"   # user-role token with register permission; NOT the owner token
 
 machines:
   - name: barn
-    os: windows
     services:
       - port: 22
         name: SSH
-      - port: 3389
-        name: RDP
-    target: host.docker.internal
+      - port: 5432
+        name: postgres
 ```
 
-Notes:
+A gateway-agent variant, fronting a NAS elsewhere on the LAN:
 
-- `hub:` must be reachable from where `telad` runs.
-  - For local development (no TLS), a `ws://localhost` hub URL is typical.
-- `token:` is required when the hub has authentication enabled (recommended for any Internet-facing hub). This is an agent token -- a user-role token with register permission on this machine -- generated with `tela admin tokens add` (or `telahubd user add` on the hub machine directly). Do not use the hub's owner token here.
-- If `target:` is omitted, `telad` assumes the services are local to the daemon host.
+```yaml
+hub: wss://hub.example.com
+token: "<agent-token>"
 
-### Quick-start with flags
+machines:
+  - name: nas
+    target: 192.168.1.50
+    services:
+      - port: 22
+        name: SSH
+```
 
-Instead of a config file, you can pass everything on the command line:
+Notes on the fields:
+
+- `hub:` must be reachable from where `telad` runs. For local development
+  without TLS, a `ws://localhost:8080` hub URL is typical.
+- `token:` is required when the hub has authentication enabled, which is
+  the default and the right choice for any internet-facing hub. Use a
+  dedicated agent token, not the hub's owner token; see
+  [Authentication](#authentication) below.
+- `target:` defaults to `127.0.0.1`. Set it to a remote address for the
+  gateway pattern.
+- `services:` can also be written as a bare port list, `ports: [22, 5432]`,
+  which registers the ports without names. Named services display better
+  in clients and are required for per-service access grants.
+
+The full machine schema (display names, tags, location, per-machine tokens,
+gateways, upstreams, file shares) is in
+[Appendix A: CLI Reference](../guide/reference.md).
+
+### Quick Start with Flags
+
+Instead of a config file, you can pass everything on the command line. The
+`-ports` flag accepts bare ports or `port:name` pairs:
 
 ```bash
-telad -hub wss://your-hub.example.com -machine barn -ports "22:SSH,3389:RDP" -token <agent-token>
+telad -hub wss://hub.example.com -machine barn -ports "22:SSH,5432:postgres" -token <agent-token>
 ```
 
-For production, prefer a config file and run `telad` as an OS service (see [Run Tela as an OS service](services.md)).
+For production, prefer a config file and run `telad` as an OS service.
 
 ## Authentication
 
-If the hub has authentication enabled (which is recommended), `telad` must present a valid token to connect.
+If the hub has authentication enabled, `telad` must present a valid token
+to connect.
 
-### Getting a token for telad
+### Getting a Token for telad
 
 From any workstation with the hub's owner token:
 
 ```bash
 # Create an identity for this agent
-tela admin tokens add barn-agent -hub wss://your-hub.example.com -token <owner-token>
-# → Save the printed token
+tela admin tokens add barn-agent -hub wss://hub.example.com -token <owner-token>
+# Save the printed token
 
 # Grant the agent permission to register the machine
-tela admin access grant barn-agent barn register -hub wss://your-hub.example.com -token <owner-token>
+tela admin access grant barn-agent barn register -hub wss://hub.example.com -token <owner-token>
 ```
 
-Or directly on the hub machine (when the hub is stopped):
+Alternatively, generate a one-time register pairing code
+(`tela admin pair-code barn -type register`) and redeem it on the agent
+host with `telad pair`; see [Credentials and Pairing](../guide/credentials.md).
+
+You can also create the identity directly on the hub machine with
+`telahubd user add barn-agent` followed by
+`telahubd user grant barn-agent barn`. Note that `telahubd user grant`
+creates a machine ACL entry without a register-token restriction, which
+means any known identity can register that machine. To restrict
+registration to one specific token, use
+`tela admin access grant barn-agent barn register` via the admin API
+instead.
+
+### Providing the Token
+
+**Credential store** (recommended for long-lived agents). On the agent
+machine, with elevation:
 
 ```bash
-telahubd user add barn-agent
-telahubd user grant barn-agent barn
-```
-
-Note: `telahubd user grant` creates a machine access control list entry for "barn" with no `registerToken` restriction, which means any known identity (including barn-agent) can register that machine. It also explicitly grants barn-agent connect access to "barn". To restrict registration to a specific token only, use `tela admin access grant barn-agent barn register` via the admin API instead.
-
-### Providing the token
-
-**Credential store** (recommended for long-lived agents):
-
-On the agent machine (requires elevation):
-
-```bash
-telad login -hub wss://your-hub.example.com
+sudo telad login -hub wss://hub.example.com
 # Prompts for token and optional identity
-# Stores in system credential store (survives service restart)
 ```
 
-The token is now automatically found whenever `telad` connects to that hub.
+The token lands in the system credential store and survives service
+restarts. From then on `telad` finds it automatically whenever it connects
+to that hub.
 
-**Config file** (recommended for YAML-based deployments):
+**Config file** (recommended for YAML-based deployments). Set the
+top-level `token:` field, or a per-machine `token:` override.
 
-```yaml
-hub: wss://your-hub.example.com
-token: "<barn-agent-token>"
+**Command line.** Pass `-token <value>`.
 
-machines:
-  - name: barn
-    ports: [22, 3389]
-```
+**Environment variable.** Set `TELA_TOKEN`.
 
-**Command line:**
+Token lookup precedence:
 
-```bash
-telad -hub wss://your-hub.example.com -machine barn -ports "22,3389" -token <barn-agent-token>
-```
-
-**Environment variable:**
-
-```bash
-export TELA_TOKEN=<barn-agent-token>
-telad -hub wss://your-hub.example.com -machine barn -ports "22,3389"
-```
-
-**Token lookup precedence:**
-
-1. `-token` flag (explicit)
+1. `-token` flag
 2. `TELA_TOKEN` environment variable
-3. Per-machine token in config file
-4. Top-level token in config file
-5. Credential store by hub URL
+3. Per-machine token in the config file
+4. Top-level token in the config file
+5. Credential store, by hub URL
 
-## Running as an OS service
+## Running as an OS Service
 
-`telad` can run as a native service on Windows, Linux, and macOS. Configuration is stored securely in the service metadata (no file permission issues).
-
-Two installation modes:
-
-**Mode 1: From a config file**
+For production, install `telad` as a native service so it starts at boot
+and restarts on failure:
 
 ```bash
 telad service install -config telad.yaml
-```
-
-The configuration is validated and stored in service metadata. A reference copy is retained on disk for manual editing.
-
-**Mode 2: Inline configuration (recommended for simple setups)**
-
-```bash
-telad service install -hub ws://your-hub:8080 -machine barn -ports "22:SSH,3389:RDP"
-```
-
-Configuration is passed as command-line flags and stored inline. No external file needed. Ideal for single-machine deployments.
-
-**Manage the service:**
-
-```bash
 telad service start
-telad service stop
-telad service restart
-telad service status
-telad service uninstall
 ```
 
-**Reconfigure:** Edit the YAML config file (if one exists) and run `telad service restart`, or reinstall with new parameters.
+See [Run Tela as an OS Service](services.md) for the two installation
+modes, platform details, and service troubleshooting.
 
-See [Run Tela as an OS service](services.md) for platform-specific details and troubleshooting.
+## UDP Relay
 
-## Service reachability checklist
+If the hub advertises a UDP relay, `telad` sends UDP to the hub's UDP port
+for faster transport. If UDP is blocked on the agent's network, sessions
+still work over the WebSocket transport; they are just slower.
 
-For each declared service:
+## Troubleshooting
 
-- Verify the service is listening on the target host.
-- Verify the `telad` host can reach `target:<port>`.
-  - In gateway mode, this is the most common failure.
+**The machine never appears in hub status.** Check the hub URL in `hub:`
+(DNS and firewall), confirm the hub is reachable from the agent's network,
+and if the hub has auth enabled, confirm the token is set and valid.
 
-## UDP relay (optional)
+**`telad` logs "auth_required" or "forbidden".** The token is missing,
+rotated away, or does not have permission to register this machine. Use
+`tela admin tokens list` to verify the identity exists and
+`tela admin access grant` to grant register permission on the machine.
 
-If the hub advertises UDP relay, `telad` may send UDP to the hub's UDP port.
-
-- If UDP is blocked, sessions still work via WebSockets.
-
-## Quick troubleshooting
-
-- Machine never appears in hub status:
-  - Check the hub URL in `hub:` (DNS + firewall).
-  - Check the hub is actually reachable from the daemon's network.
-  - If the hub has auth enabled, check that `token:` is set and the token is valid.
-- `telad` logs "auth_required" or "forbidden":
-  - The token is missing, expired, or does not have permission to register this machine. Use `tela admin tokens list` to verify the identity exists, and `tela admin access grant` to grant machine access.
-- Services show but connect fails:
-  - In gateway mode, confirm reachability from daemon to target on the service port.
+**The machine shows up but connecting to a service fails.** Verify the
+service is actually listening on the target host. In the gateway pattern,
+verify the agent host can reach `target:<port>`; that hop is the most
+common failure.

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -6,9 +6,9 @@ Tela is a connectivity fabric. It is a small set of programs that lets one
 machine reach a TCP service on another machine through an encrypted tunnel,
 without either side opening an inbound port, installing a virtual private
 network (VPN) client, loading a kernel driver, or running anything as root
-or Administrator. Remote desktop is the use case I built it for first.
-Remote desktop is just one application that runs on the fabric, not the
-point of it.
+or Administrator. Remote desktop was the first use case the project was
+built for, but remote desktop is just one application that runs on the
+fabric, not the point of it.
 
 The point of the fabric is that the same three pieces scale from a single
 laptop reaching a single home server all the way up to a fleet of machines
@@ -19,21 +19,21 @@ a client (`tela`) that runs on the machine you want to reach from. Each is
 a single static binary with no runtime dependencies. They run on Windows,
 Linux, and macOS.
 
-| Tier | What it looks like |
+| Tier | What It Looks Like |
 |------|---------------------|
 | **Solo remote access** | One agent, one hub, one client. A few minutes from download to first connection. |
 | **Personal cloud** | Several agents at home and work, file sharing, a desktop client for non-terminal users. |
 | **Team cloud** | Named identities, per-machine permissions, pairing codes for onboarding, audit history, remote admin from the desktop client. |
 | **Fleet** | Multiple hubs registered with a directory, identities and permissions managed centrally, agents updating themselves through release channels. |
 
-The next chapter, [What Tela is](getting-started/what-tela-is.md), covers
+The next chapter, [What Tela Is](getting-started/what-tela-is.md), covers
 the substrate properties, the design tradeoffs against existing tools, and
 the things Tela is explicitly not trying to be. It is the concept primer.
 After that, [Installation](getting-started/installation.md) and
-[First connection](getting-started/first-connection.md) get you to a working
+[First Connection](getting-started/first-connection.md) get you to a working
 tunnel.
 
-## How this book is organized
+## How This Book Is Organized
 
 Tela is the substrate. This book documents the substrate first and the
 features built on top of it second.
@@ -45,16 +45,16 @@ features built on top of it second.
   clients.
 - The [How-to Guides](howto/channels.md) section is a set of focused
   walkthroughs for the most common operational tasks.
-- The [Use Cases](use-cases/personal-cloud.md) section walks through six
-  concrete deployment scenarios with the access model and the deployment
-  pattern for each.
+- The [Use Cases](use-cases/personal-cloud.md) section maps seven concrete
+  deployment scenarios onto the fabric: the topology, the access model, and
+  the pitfalls specific to each.
 - The [Operations](ops/release-process.md) section covers the release
   process for hub and agent operators.
 - The [Design Rationale](architecture/design.md) section answers the
   *why* questions: why three small daemons rather than one, why the hub
   is a blind relay, why remote administration works through the hub
   rather than directly, why file sharing has its own dedicated protocol,
-  and why the gateway is a primitive that recurs at four layers. Read it
+  and why the gateway is a primitive that recurs at several layers. Read it
   after the body of the book if you want to understand the project's
   design decisions and the alternatives that were considered and rejected.
 - The [Appendices](guide/reference.md) collect reference data: the CLI
@@ -71,13 +71,13 @@ matches the binaries on the stable channel.
 - The three binaries are `tela` (client), `telad` (agent or daemon), and
   `telahubd` (hub or relay).
 - "TelaVisor" is the desktop graphical interface built on top of `tela`.
-- A "group" is one hub and the agents connected to it -- the basic
+- A "group" is one hub and the agents connected to it, the basic
   operational unit. A "fleet" is a collection of groups. The analogy is
   a carrier battle group (hub as carrier, agents as support vessels) within
   a fleet.
 - A "hub directory" is anything that responds to the small Tela directory
   protocol; a "portal" is a directory plus extras (dashboard, identity,
-  audit). See [Hub directories and portals](guide/directories.md).
+  audit). See [Hub Directories and Portals](guide/directories.md).
 - Code, file paths, command-line flags, and configuration keys are in
   `monospace`.
 - Mermaid diagrams render natively in the HTML output.
@@ -87,4 +87,3 @@ matches the binaries on the stable channel.
 Apache License 2.0. See the
 [LICENSE](https://github.com/paulmooreparks/tela/blob/main/LICENSE) file in
 the repository.
-

--- a/book/src/ops/release-process.md
+++ b/book/src/ops/release-process.md
@@ -1,76 +1,93 @@
-# Release process
+# Release Process
 
-Tela releases move through a three-channel pipeline: dev, beta, and stable. The [Self-update and release channels](../howto/channels.md) chapter in the How-to Guide covers the user-facing side. The sections below cover the internal model for operators and maintainers who need to cut a release, promote a channel, or issue a hotfix.
+Tela releases move through a three-channel pipeline: dev, beta, and stable.
+The [Self-Update and Release Channels](../howto/channels.md) chapter covers
+the user-facing side. This chapter covers the internal model for operators
+and maintainers who need to cut a release, promote a channel, or issue a
+hotfix, plus how to run a fully self-hosted channel server.
 
 ## Channels
 
-Tela ships through three release channels. A channel is a named pointer that resolves to a single tag. Self-update on every Tela binary follows its configured channel.
+A channel is a named pointer that resolves to a single tag. Self-update on
+every Tela binary follows its configured channel.
 
 | Channel | Purpose | Cadence | Audience | Risk |
 |---------|---------|---------|----------|------|
 | **dev** | Latest unstable build. Every push to `main` produces a new dev build. | Per commit | Maintainers, contributors, dogfood rigs | Highest. May break, may have half-finished features. |
-| **beta** | Promoted dev builds ready for wider exposure. Cut by hand when a dev build is ready for promotion. | Days to weeks | Early adopters, staging deployments, dev hubs | Moderate. Real bugs surface here. |
+| **beta** | Promoted dev builds ready for wider exposure. Cut by hand when a dev build is ready. | Days to weeks | Early adopters, staging deployments, dev hubs | Moderate. Real bugs surface here. |
 | **stable** | Promoted beta builds that have been exercised in beta. The default for new installations after 1.0. | Weeks to months | Production deployments, public hubs, package managers | Low. Bug fixes only between minor versions. |
 
-Pre-1.0, every binary defaults to `dev`. The channel mechanism works for all three channels today, but `dev` is the appropriate default while the project is moving fast and `stable` is not yet the load-bearing public face it will be after 1.0.
+Pre-1.0, every binary defaults to `dev`. The channel mechanism works for
+all three channels today, but `dev` is the appropriate default while the
+project is moving fast. Post-1.0, TelaVisor and the Tela binaries default
+to `stable`, and opting into beta or dev becomes a deliberate choice.
 
-Post-1.0, TelaVisor and the Tela binaries default to `stable`. New installations get the conservative line by default; opting into beta or dev becomes a deliberate choice.
+What changes at 1.0 is the meaning of `stable`, not its existence. Pre-1.0,
+a stable tag is the build most ready for promotion, with no compatibility
+promise. Post-1.0 it carries the backward-compatibility guarantees
+described below.
 
-What changes at 1.0 is the meaning of `stable`, not its existence. Pre-1.0, a stable tag is the build most ready for promotion, with no compatibility promise. Post-1.0 it carries the backward-compatibility guarantees described below.
+Users change channel through TelaVisor's Updates tab, via the
+`channel set` subcommand of any binary, or by editing the `update.channel`
+field in the hub or agent YAML config.
 
-Users can change channel through TelaVisor's Application Settings, via the `channel set` subcommand of any binary (`tela channel set <name>`, `telad channel set <name>`, `telahubd channel set <name>`), or by editing the `update.channel` field in their hub or agent YAML config.
+## Tag Naming
 
-## Tag naming
+Tela uses semantic versioning with prerelease suffixes for non-stable
+channels.
 
-Tela uses semantic versioning with prerelease suffixes for non-stable channels.
-
-| Channel | Tag form | Example |
+| Channel | Tag Form | Example |
 |---------|----------|---------|
-| dev | `vMAJOR.MINOR.0-dev.PATCH` | `v0.4.0-dev.42` |
-| beta | `vMAJOR.MINOR.0-beta.N` | `v0.4.0-beta.3` |
-| stable | `vMAJOR.MINOR.PATCH` | `v0.4.0`, `v0.4.1`, `v1.0.0` |
+| dev | `vMAJOR.MINOR.0-dev.PATCH` | `v0.16.0-dev.15` |
+| beta | `vMAJOR.MINOR.0-beta.N` | `v0.16.0-beta.1` |
+| stable | `vMAJOR.MINOR.PATCH` | `v0.16.0`, `v0.15.0` |
 
-The `MAJOR.MINOR` portion comes from the `VERSION` file at the repository root. It is the next stable version that maintainers are working toward. When `VERSION` says `0.4`, dev builds are `v0.4.0-dev.N` and the next stable will be `v0.4.0`.
+The `MAJOR.MINOR` portion comes from the `VERSION` file at the repository
+root. It is the next stable version that maintainers are working toward.
+When `VERSION` says `0.16`, dev builds are `v0.16.0-dev.N` and the next
+stable will be `v0.16.0`.
 
-After cutting a stable release, bump `VERSION` to the next minor (for example, `0.4` to `0.5`). This resets the dev counter for the next development cycle.
+After a stable release, `VERSION` is bumped to the next minor in a
+follow-up commit to `main`. That push itself produces the new series' first
+dev build (for example, `v0.17.0-dev.1`).
 
 Semver compares prerelease versions in the correct order:
 
 ```
-v0.4.0-dev.5 < v0.4.0-dev.42 < v0.4.0-beta.1 < v0.4.0-beta.3 < v0.4.0 < v0.4.1
+v0.16.0-dev.5 < v0.16.0-dev.15 < v0.16.0-beta.1 < v0.16.0-beta.3 < v0.16.0 < v0.16.1
 ```
-
-## Branches
-
-Three branches mirror the three channels.
-
-| Branch | Channel | Who can push | Trigger |
-|--------|---------|--------------|---------|
-| `main` | dev | Maintainers, contributors via PR | Auto-tag on every push, builds dev release |
-| `beta` | beta | Maintainers only, fast-forward only | Tag push triggers a beta release build |
-| `release` | stable | Maintainers only, fast-forward only | Tag push triggers a stable release build |
-
-Branches flow forward only: `main` to `beta` to `release`. A fix lands on `main` first, soaks, gets promoted to `beta`, soaks again, gets promoted to `release`. There is no shortcut.
-
-Hotfixes are the exception. If a critical bug is in a stable release, a fix can be cherry-picked from `main` directly to a `hotfix/v0.4.x` branch off the stable tag, tagged as `v0.4.1`, and immediately released. The same fix must then be merged forward into `beta` and `main` to prevent drift.
-
-The `beta` and `release` branches exist so anyone reading the GitHub branch list can see what is currently on each channel, but `promote.yml` does not require them: it tags commits directly. The forward-only flow is policy; the branches are bookkeeping.
 
 ## Promotion
 
-Promotion is always manual. There is no automatic dev-to-beta or beta-to-stable. A maintainer reviews what is on the source channel, decides it is ready, and runs the promotion workflow.
+Promotion is always manual. There is no automatic dev-to-beta or
+beta-to-stable. A maintainer reviews what is on the source channel, decides
+it is ready, and runs the promotion workflow.
 
-Promotion happens via `.github/workflows/promote.yml`, triggered manually with three inputs:
+Promotion happens via `.github/workflows/promote.yml`, triggered manually
+with three inputs:
 
-- **`source_tag`** -- the existing tag being promoted (e.g. `v0.4.0-dev.42`)
-- **`target_channel`** -- `beta` or `stable`
-- **`target_version`** -- required only for stable promotions (e.g. `v0.4.0`)
+- **`source_tag`**: the existing tag being promoted (for example,
+  `v0.16.0-dev.15`)
+- **`target_channel`**: `beta` or `stable`
+- **`target_version`**: required only for stable promotions (for example,
+  `v0.16.0`)
 
-The workflow validates the source tag, computes the new tag name (auto-incremented for beta, user-chosen for stable), creates the new tag pointing at the same commit, and pushes it. The tag push triggers `release.yml` to build and publish.
+The workflow validates the source tag, computes the new tag name
+(auto-incremented for beta, maintainer-chosen for stable), creates the new
+tag pointing at the same commit, and pushes it. The tag push triggers
+`release.yml` to build and publish. Promotion never rebuilds from a
+different commit: the beta and the dev build it came from are the same
+source, and likewise for stable.
 
-## Channel manifests
+Everything flows forward: a fix lands on `main` first, soaks on dev, gets
+promoted to beta, soaks again, gets promoted to stable. Hotfixes are the
+one exception, covered below.
 
-Each channel has a JSON manifest hosted as a release asset on a special `channels` GitHub Release. The manifest is the canonical answer to "what version is current on this channel?"
+## Channel Manifests
+
+Each channel has a JSON manifest hosted as a release asset on a rolling
+`channels` GitHub Release. The manifest is the canonical answer to "what
+version is current on this channel?"
 
 ```
 https://github.com/paulmooreparks/tela/releases/download/channels/dev.json
@@ -83,10 +100,10 @@ Schema:
 ```json
 {
   "channel": "dev",
-  "version": "v0.4.0-dev.42",
-  "tag": "v0.4.0-dev.42",
-  "publishedAt": "2026-04-08T12:00:00Z",
-  "downloadBase": "https://github.com/paulmooreparks/tela/releases/download/v0.4.0-dev.42/",
+  "version": "v0.16.0-dev.15",
+  "tag": "v0.16.0-dev.15",
+  "publishedAt": "2026-07-11T12:00:00Z",
+  "downloadBase": "https://github.com/paulmooreparks/tela/releases/download/v0.16.0-dev.15/",
   "binaries": {
     "tela-linux-amd64":       { "sha256": "abc...", "size": 12345678 },
     "tela-windows-amd64.exe": { "sha256": "def...", "size": 12345678 },
@@ -95,121 +112,154 @@ Schema:
 }
 ```
 
-The schema is part of Tela's public API after 1.0. Adding new optional fields is a minor-version change; renaming or removing existing fields is a major-version change.
+The schema is part of Tela's public API after 1.0. Adding new optional
+fields is a minor-version change; renaming or removing existing fields is a
+major-version change.
 
-## What `release.yml` does
+## What release.yml Does
 
 The release workflow runs in three cases:
 
-1. **Push to `main`** -- produces a dev build, tagged `v{VERSION}.0-dev.{PATCH}`, and updates `dev.json`.
-2. **Push of a tag matching `v*-beta*`** -- produces a beta build and updates `beta.json`.
-3. **Push of a tag matching `v*` without a prerelease suffix** -- produces a stable build and updates `stable.json`.
+1. **Push to `main`**: produces a dev build, tagged
+   `v{VERSION}.0-dev.{PATCH}`, and updates `dev.json`. The workflow has a
+   paths filter, so pushes that touch only documentation do not produce a
+   build; docs-only changes ride along with the next code-triggered tag.
+2. **Push of a tag matching `v*-beta*`**: produces a beta build and updates
+   `beta.json`.
+3. **Push of a tag matching `v*` without a prerelease suffix**: produces a
+   stable build and updates `stable.json`.
 
-In all three cases the workflow builds Linux, macOS, and Windows binaries for amd64 and arm64, generates SHA256 checksums and the per-release manifest, and creates or updates the GitHub Release for that tag. For TelaVisor specifically, the workflow also builds `.deb` and `.rpm` packages and a Windows NSIS installer; the CLI binaries (`tela`, `telad`, `telahubd`) are distributed as plain executables only.
+In all three cases the workflow builds Linux, macOS, and Windows binaries
+for amd64 and arm64, generates SHA-256 checksums and the per-release
+manifest, and creates or updates the GitHub Release for that tag. For
+TelaVisor specifically, the workflow also builds `.deb` and `.rpm` packages
+and a Windows NSIS installer; the CLI binaries (`tela`, `telad`,
+`telahubd`) are distributed as plain executables. Every tag also rebuilds
+the corresponding edition of this book.
 
 ## Cadence
 
 Pre-1.0:
 
 - **Dev**: every commit. No promise of stability.
-- **Beta**: cut on demand when a dev build deserves wider exposure. No fixed cadence.
-- **Stable**: cut on demand when a beta is ready for promotion. Pre-1.0 stable releases carry no backward-compatibility promise -- that begins at `v1.0.0`. Use them as the build most ready for promotion, not as a long-term support line.
+- **Beta**: cut on demand when a dev build deserves wider exposure.
+- **Stable**: cut on demand when a beta is ready. Pre-1.0 stable releases
+  carry no backward-compatibility promise; that begins at `v1.0.0`.
 
 Post-1.0:
 
 - **Dev**: every commit.
-- **Beta**: roughly every two weeks when there is meaningful work on `main`.
-- **Stable**: patch releases as needed for bug fixes; minor releases roughly monthly when there is enough new functionality; major releases rare, deliberate, with a long beta phase and an upgrade guide.
+- **Beta**: roughly every two weeks when there is meaningful work on
+  `main`.
+- **Stable**: patch releases as needed for bug fixes; minor releases
+  roughly monthly when there is enough new functionality; major releases
+  rare and deliberate, with a long beta phase and an upgrade guide.
 
 These are guidelines, not promises.
 
-## Backward-compatibility commitments
+## Backward-Compatibility Commitments
 
 After 1.0:
 
-- The wire protocol is frozen for `1.x`. Adding new optional fields is allowed; removing or renaming fields is a major-version change.
-- The public CLI surface (command names, flag names, output formats) is frozen for `1.x`. Adding new commands or flags is allowed; removing them is a major-version change.
-- The hub admin REST API is frozen for `1.x`. Adding new endpoints is allowed; removing or breaking existing ones is a major-version change.
-- Config file schemas (`telahubd.yaml`, `telad.yaml`, `hubs.yaml`, profile YAML) are frozen for `1.x`. New optional fields are allowed; removing or renaming required fields is a major-version change.
+- The wire protocol is frozen for `1.x`. Adding new optional fields is
+  allowed; removing or renaming fields is a major-version change.
+- The public CLI surface (command names, flag names, output formats) is
+  frozen for `1.x`. Adding new commands or flags is allowed; removing them
+  is a major-version change.
+- The hub admin REST API is frozen for `1.x`. Adding new endpoints is
+  allowed; removing or breaking existing ones is a major-version change.
+- Config file schemas (`telahubd.yaml`, `telad.yaml`, `hubs.yaml`, profile
+  YAML) are frozen for `1.x`. New optional fields are allowed; removing or
+  renaming required fields is a major-version change.
 - The channel manifest schema is frozen for `1.x`.
 
-A bug fix to a `1.x` line will never introduce a breaking change. If a fix requires breaking compatibility, it ships in `2.0`, not `1.x`.
+A bug fix to a `1.x` line will never introduce a breaking change. If a fix
+requires breaking compatibility, it ships in `2.0`, not `1.x`.
 
-Pre-1.0: nothing is frozen. Cruft and broken shapes are removed aggressively.
+Pre-1.0: nothing is frozen. Cruft and broken shapes are removed
+aggressively.
 
-## Deprecation policy
+## Deprecation Policy
 
 When a feature is deprecated in a `1.x` release:
 
-1. The feature continues to work unchanged in all subsequent `1.x` releases.
-2. The deprecation is announced in the release notes and marked in the relevant docs.
+1. The feature continues to work unchanged in all subsequent `1.x`
+   releases.
+2. The deprecation is announced in the release notes and marked in the
+   relevant docs.
 3. The CLI emits a warning to stderr when the deprecated feature is used.
 4. The feature is removed in the next major release (`2.0`).
 
-A feature deprecated in `1.5` works in `1.5`, `1.6`, `1.7`, and is removed in `2.0`.
+A feature deprecated in `1.5` works in `1.5`, `1.6`, `1.7`, and is removed
+in `2.0`.
 
-## End-of-life policy
+## End-of-Life Policy
 
-Each major version is supported with security fixes and critical bug fixes for 12 months after the next major version ships. When `2.0` ships, `1.x` continues to receive fixes for 12 months, after which only `2.x` is supported. The end-of-life date for the previous major is announced in the release notes for the new major.
+Each major version is supported with security fixes and critical bug fixes
+for 12 months after the next major version ships. When `2.0` ships, `1.x`
+continues to receive fixes for 12 months, after which only `2.x` is
+supported. The end-of-life date for the previous major is announced in the
+release notes for the new major.
 
-## Quick reference for maintainers
+## Quick Reference for Maintainers
 
 **Cut a beta from a dev build:**
 
 ```
 GitHub -> Actions -> Promote -> Run workflow
-  source_tag:     v0.4.0-dev.42
+  source_tag:     v0.16.0-dev.15
   target_channel: beta
   target_version: (leave empty)
 ```
 
-This creates `v0.4.0-beta.{N+1}` and triggers the beta release build.
+This creates `v0.16.0-beta.{N+1}` and triggers the beta release build.
 
 **Cut a stable from a beta build:**
 
 ```
 GitHub -> Actions -> Promote -> Run workflow
-  source_tag:     v0.4.0-beta.3
+  source_tag:     v0.16.0-beta.3
   target_channel: stable
-  target_version: v0.4.0
+  target_version: v0.16.0
 ```
 
-This creates `v0.4.0` and triggers the stable release build. After it completes, bump `VERSION` to `0.5` in a follow-up commit so dev builds start counting toward the next minor.
+This creates `v0.16.0` and triggers the stable release build. After it
+completes, bump `VERSION` to `0.17` in a follow-up commit so dev builds
+start counting toward the next minor.
 
 **Cut a hotfix:**
 
 ```bash
-git checkout v0.4.0
-git checkout -b hotfix/v0.4.x
+git checkout v0.16.0
+git checkout -b hotfix/v0.16.x
 git cherry-pick <fix-commit>
-git tag v0.4.1
-git push origin hotfix/v0.4.x v0.4.1
+git tag v0.16.1
+git push origin hotfix/v0.16.x v0.16.1
 ```
 
-The tag push triggers a stable release build for `v0.4.1`. Then merge the cherry-picked commit forward into `main` so it is not lost.
+The tag push triggers a stable release build for `v0.16.1`. Then merge the
+cherry-picked commit forward into `main` so it is not lost.
 
-## Self-hosted channels on telahubd
+## Self-Hosted Channels on telahubd
 
-Any `telahubd` hub can serve release channel manifests and binary
-downloads in-process. Enable the `channels:` block in `telahubd.yaml`
-and the hub will mount public `/channels/` routes alongside the rest
-of its HTTP surface. The wire format matches the GitHub-hosted
-channels exactly, so clients pointed at a self-hosted channel with
-`update.sources[<name>]` fetch and verify manifests through the same
-code path as they use for the public channel.
-
-Prior to 0.12 this was a separate binary named `telachand`. The
-standalone daemon has been retired; the channel-hosting code now
-lives inside telahubd.
+Any `telahubd` hub can serve release channel manifests and binary downloads
+in-process. Enable the `channels:` block in `telahubd.yaml` and the hub
+mounts public `/channels/` routes alongside the rest of its HTTP surface.
+The wire format matches the GitHub-hosted channels exactly, so clients
+pointed at a self-hosted channel with `update.sources[<name>]` fetch and
+verify manifests through the same code path they use for the public
+channels.
 
 Use cases:
 
 - Air-gapped or firewall-restricted networks where GitHub is unreachable
-- Distributing custom or private builds that never enter the public pipeline
+- Distributing custom or private builds that never enter the public
+  pipeline
 - Staging a release internally before pushing it to the public channel
-- Developer workflows where every local build becomes immediately available for self-update across a local fleet
+- Developer workflows where every local build becomes immediately available
+  for self-update across a local fleet
 
-### Enable the channel server
+### Enable the Channel Server
 
 Add a `channels:` block to `telahubd.yaml`:
 
@@ -229,22 +279,23 @@ channels:
 
 Restart the hub. The new routes are:
 
-- `GET /channels/{name}.json` -- channel manifest
-- `GET /channels/files/` -- directory listing of all channels
-- `GET /channels/files/{channel}/` -- directory listing of one channel
-- `GET /channels/files/{channel}/{binary}` -- binary download
-- `GET /channels/` -- health/status JSON
+- `GET /channels/{name}.json`: channel manifest
+- `GET /channels/files/`: directory listing of all channels
+- `GET /channels/files/{channel}/`: directory listing of one channel
+- `GET /channels/files/{channel}/{binary}`: binary download
+- `GET /channels/`: health and status JSON
 
-Each channel has its own subdirectory under `files/` so parallel
-publishes to different channels do not overwrite each other.
+Each channel has its own subdirectory under `files/`, so parallel publishes
+to different channels do not overwrite each other.
 
 The endpoints are public (no auth, wildcard CORS) by design. Release
-manifests are world-readable. Do not place anything in `channels.data`
-that you would not want served.
+manifests are world-readable. Do not place anything in `channels.data` that
+you would not want served.
 
-### Populate the files directory
+### Populate the Files Directory
 
-Drop binaries into `{data}/files/{channel}/` using the same naming convention as GitHub release assets:
+Drop binaries into `{data}/files/{channel}/` using the same naming
+convention as GitHub release assets:
 
 ```
 {data}/files/
@@ -253,24 +304,21 @@ Drop binaries into `{data}/files/{channel}/` using the same naming convention as
     tela-windows-amd64.exe
     telad-linux-amd64
     ...
-  beta/
-    tela-linux-amd64
-    ...
   local/
     tela-linux-amd64
     ...
 ```
 
 Only include the binaries you want to distribute on each channel. The
-manifest lists whatever is present in that channel's directory;
-clients look up their own platform entry.
+manifest lists whatever is present in that channel's directory; clients
+look up their own platform entry.
 
-### Publish a manifest
+### Publish a Manifest
 
 After placing binaries, generate the manifest:
 
 ```bash
-telahubd channels publish -channel dev -tag v0.12.0-dev.1
+telahubd channels publish -channel dev -tag v0.16.0-dev.15
 ```
 
 Output:
@@ -281,113 +329,66 @@ Output:
   ...
 
 published dev channel manifest
-  tag:      v0.12.0-dev.1
+  tag:      v0.16.0-dev.15
   binaries: 9
   base:     https://hub.example.net/channels/files/
   manifest: /var/lib/telahubd/channels/dev.json
 ```
 
-The manifest is live immediately. The hub does not need to restart.
-Each channel has its own manifest; you can maintain all three
-(or any named custom channels) simultaneously.
+The manifest is live immediately, with no hub restart. Each channel has its
+own manifest; you can maintain the three standard channels and any named
+custom channels simultaneously.
 
-### Publishing from a separate build machine
+The manifest tag is arbitrary. For local dev builds, a short git hash or a
+timestamp works, since `dev`-versioned binaries always update regardless of
+semver comparison.
 
-The CLI `telahubd channels publish` runs on the same host as the hub
-and reads `channels.data` from the hub's config file. When your build
-pipeline lives elsewhere, use the HTTPS admin API instead:
+### Publishing from a Separate Build Machine
 
-- `PUT /api/admin/channels/files/{channel}/{binary}` uploads a file
-  into `channels.data/files/{channel}/`. Request body is the file
-  bytes. Owner or admin token required. 500 MiB max per file.
-- `POST /api/admin/channels/publish` with
-  `{"channel":"...","tag":"..."}` hashes everything under
-  `channels.data/files/{channel}/` and writes the manifest. Returns
-  the manifest JSON for verification.
+`telahubd channels publish` runs on the same host as the hub and reads
+`channels.data` from the hub's config file. When your build pipeline lives
+elsewhere, use the HTTPS admin API instead:
+
+- `PUT /api/admin/channels/files/{channel}/{binary}` uploads a file into
+  `channels.data/files/{channel}/`. The request body is the file bytes.
+  Owner or admin token required. 500 MiB max per file.
+- `POST /api/admin/channels/publish` with `{"channel":"...","tag":"..."}`
+  hashes everything under `channels.data/files/{channel}/` and writes the
+  manifest. It returns the manifest JSON for verification.
 
 Upload each binary, then call `/publish` once. No SSH, tunnel, or
 file-share mount is needed on the build host.
 
-Reference implementations live under `scripts/` in the tela repo.
-Pick the one for your host OS:
-
-- `scripts/publish-channel.ps1` -- PowerShell 5.1+ / PowerShell 7, for Windows
-- `scripts/publish-channel.sh` -- bash 4+, for Linux and macOS
-
-Both do the same job: cross-compile tela/telad/telahubd for Linux and
-Windows amd64, bundle TelaVisor via `wails build` (Windows binary on
-PowerShell, host-platform binary on bash), and run the upload + publish
-round-trip against any hub with channels hosting enabled.
-
-Configuration comes from `scripts/publish.env` (gitignored):
+Reference implementations live under `scripts/` in the tela repo:
+`scripts/publish-channel.ps1` (PowerShell, for Windows) and
+`scripts/publish-channel.sh` (bash, for Linux and macOS). Both
+cross-compile the CLI binaries, bundle TelaVisor via `wails build`, and run
+the upload and publish round-trip against any hub with channels hosting
+enabled. Configuration comes from `scripts/publish.env` (gitignored):
 
 ```
 TELA_PUBLISH_HUB_URL=https://hub.example.net
 TELA_PUBLISH_TOKEN=<owner-or-admin-token>
 ```
 
-Get the owner token with `telahubd user show-owner` on the hub (or
-`docker exec <container> telahubd user show-owner -config
-/app/data/telahubd.yaml` on a Dockerised hub). See
+Get the owner token with `telahubd user show-owner` on the hub. See
 `scripts/publish.env.example` for all supported keys.
 
-#### Bootstrapping a self-hosted channel pipeline
+Two pitfalls worth knowing:
 
-The HTTPS remote-publish endpoints shipped in Tela 0.12. A brand new
-self-hosted hub starts out with whichever telahubd binary the Docker
-image was built against; if that predates 0.12, it has no
-`/api/admin/channels/*` routes and `publish-channel.ps1` will 404.
+- **Version string vs. code version.** A binary's version string is set at
+  build time and does not prove which features its code has. If a publish
+  returns 404 against a hub whose banner reports a version that should
+  have the channels admin API, the hub is probably running a binary built
+  from an older commit; update the hub binary first. A quick check that
+  the endpoint exists: an unauthenticated
+  `POST /api/admin/channels/publish` should return 401, not 404.
+- **Counter drift.** The per-channel build counter in
+  `scripts/{channel}-build-counter` increments on every run, including
+  failed ones, so version tags never collide even across failed attempts.
+  This is intentional.
 
-There is therefore a one-time chicken-and-egg for any hub that is
-itself the only place you have published to: you cannot upload the
-new telahubd binary through its own admin API until it already has
-the admin API. The workaround is a single manual hop:
-
-1. Build locally with `publish-channel.ps1` -- the build step succeeds
-   even when the upload step fails, so your `dist/` directory ends up
-   with a fresh Tela 0.12+ binary set.
-2. Get those binaries onto the hub by any out-of-band means you
-   currently use: copy into an existing OneDrive/S3/nginx host that
-   the hub's `CHANNEL_MANIFEST_URL` build arg points at, `docker cp`
-   into the hub container, a temporary file mount, etc.
-3. Rebuild the hub image so it picks up the new binaries:
-   `docker compose build <hub-service> && docker compose up -d <hub-service>`.
-4. Verify the admin endpoint now exists. A POST without auth should
-   return 401, not 404:
-   ```
-   curl -s -o /dev/null -w '%{http_code}\n' -X POST \
-     https://hub.example.net/api/admin/channels/publish
-   ```
-5. Populate `scripts/publish.env` and run `publish-channel.ps1`
-   again. From this point on every subsequent publish goes straight
-   through the HTTPS admin API.
-
-The specific out-of-band hop in step 2 is unique to each operator's
-pre-0.12 topology. Once the hub has 0.12+ telahubd, the pipeline is
-self-sufficient and the workaround is never needed again.
-
-#### Common pitfalls
-
-- **Version string vs. code version.** The binary's `main.version`
-  string is set by ldflags at build time; it does not imply the code
-  in that binary has any specific feature. If `publish-channel.ps1`
-  404s against a hub whose banner reports a version tag that should
-  have the admin API, you are probably running a binary whose
-  `dist/` copy was built from an older commit. Re-run
-  `publish-channel.ps1` to force a fresh build from the current tip
-  and bootstrap through step 2 once more.
-- **Token mismatch.** `publish.env` holds a token per hub; if you
-  have multiple hubs, you need one `publish.env` per deployment or a
-  way to select between them. The simplest approach is one script
-  working copy per hub.
-- **Counter drift.** The per-channel build counter lives in
-  `scripts/{channel}-build-counter` and increments on every run,
-  including failed runs. A failed publish still bumps the counter;
-  subsequent successful publishes pick up from there. This is
-  intentional -- version tags should never collide even across
-  failed attempts.
-
-### Point binaries at the self-hosted channel
+### Point Binaries at the Self-Hosted Channel
 
 Each binary has a `channel sources` subcommand that writes into its
 config's `update.sources` map:
@@ -409,29 +410,5 @@ update:
 ```
 
 After this, `tela update`, `telad update`, `telahubd update`, and the
-TelaVisor Update buttons all pull from your hub.
-
-### Verify
-
-```bash
-tela channel
-```
-
-```text
-  channel:         dev
-  manifest:        https://hub.example.net/channels/dev.json
-  current version: dev
-  latest version:  v0.12.0-dev.1  (update available)
-```
-
-### Publishing new builds
-
-When you have new binaries:
-
-1. Copy them into `{data}/files/`, replacing the previous versions.
-2. Run `telahubd channels publish -channel <name> -tag <new-tag>`.
-3. Clients pull the update on their next `update` invocation.
-
-The manifest tag is arbitrary. For local dev builds, a short git hash
-or timestamp works well since `dev`-versioned binaries always update
-regardless of semver comparison.
+TelaVisor update buttons all pull from your hub. Verify with
+`tela channel`, which prints the manifest URL it will use.

--- a/book/src/ops/status.md
+++ b/book/src/ops/status.md
@@ -1,4 +1,4 @@
-# Status: design vs. implementation
+# Status: Design vs. Implementation
 
 This is the traceability matrix that maps every section of the design documents to its implementation status. It is a living document generated from the repository and updated on every push. Use it to see at a glance what is shipped, what is in progress, and what is still on paper.
 

--- a/book/src/use-cases/distributed-teams.md
+++ b/book/src/use-cases/distributed-teams.md
@@ -1,12 +1,15 @@
-# Distributed teams
+# Distributed Teams
 
-## The scenario
+Your engineering team is spread across cities and time zones. You have
+shared development and staging infrastructure (databases, internal HTTP
+services, build servers) that team members need to reach from home offices,
+co-working spaces, and laptops on the road.
 
-Your engineering team is spread across multiple cities or time zones. You have shared development and staging infrastructure -- databases, internal HTTP services, build servers -- that team members need to reach from their home offices, co-working spaces, and laptops on the road.
-
-A team VPN works, but it requires a VPN server, client configuration on every laptop, and gives access to the whole network rather than specific services. Tela takes a different approach: each shared resource registers itself with a hub under a named identity, and each team member gets a token scoped to exactly the machines and services their role needs.
-
-When a developer connects, they see only the machines they have been granted access to:
+A team VPN works, but it requires a VPN server, client configuration on
+every laptop, and it grants access to a whole network rather than to
+specific services. Tela inverts that: each shared resource registers itself
+with a hub under a named identity, and each team member gets a token scoped
+to exactly the machines their role needs.
 
 ```
 Services available:
@@ -15,188 +18,80 @@ Services available:
   localhost:8080   → HTTP         (staging-app)
 ```
 
-A new hire gets onboarded with a pairing code -- they redeem it with one command and immediately have access to the right machines. When they leave, their identity is removed and access ends across all machines at once.
+A new hire redeems a pairing code with one command and immediately has the
+right access. When someone leaves, removing one identity ends their access
+to everything at once.
 
-## Design goals for teams
+## Topology
 
-- Avoid distributing IP addresses and per-machine VPN configs.
-- Expose only the services teams need (service-level access, not full-network access).
-- Keep onboarding simple (download one binary, connect).
+Pick a hub strategy first, because it defines your isolation boundaries:
 
----
+- **One hub per environment** (`dev`, `staging`, `prod`) is the right
+  default for a single organization. Different environments get different
+  identity lists and cannot leak into each other.
+- **One hub per site** fits teams organized around physical locations.
+- **One hub per customer** is the MSP pattern; see
+  [MSP and IT Support](msp-it-support.md).
 
-## Step 0 - Pick a hub strategy
+Shared machines run endpoint agents as OS services. A machine that hosts
+several internal HTTP tools is a good candidate for a
+[path gateway](../guide/gateway.md), so the team reaches all of them
+through one port and one origin. For sites with hardware that cannot run
+`telad` (printers, appliances), one bridge agent per site can front them;
+see the gateway pattern in [Run an Agent](../howto/telad.md).
 
-Common approaches:
+## The Access Model
 
-- **One hub per environment**: `dev`, `staging`, `prod`.
-- **One hub per site**: `office-a`, `office-b`, `cloud`.
-- **One hub per customer/tenant** (for MSP-like setups).
-
-Start with **one hub per environment** if you have a single organization.
-
----
-
-## Step 1 - Run the hub(s)
-
-See [Run a hub on the public internet](../howto/hub.md) for the full hub deployment guide, including TLS setup and cloud firewall rules. For a quick start on a host with a public address:
-
-```bash
-telahubd
-```
-
-The hub prints an owner token on first start. Save it. Make each hub reachable over `wss://` (public VM or reverse proxy). Ensure WebSockets work.
-
----
-
-## Step 2 - Set up authentication
-
-Create tokens for agents and developers on each hub:
+The shape that scales: one agent identity per shared machine, one identity
+per human, connect grants that follow roles.
 
 ```bash
-# Create agent tokens (one per telad instance)
-tela admin tokens add telad-dev-db01 -hub wss://dev-hub.example.com -token <owner-token>
-# Save the printed token -- this is <agent-token> used in telad on dev-db01 (Step 3)
+# A shared dev database
+tela admin tokens add agent-dev-db01 -hub wss://dev-hub.example.com
+tela admin access grant agent-dev-db01 dev-db01 register -hub wss://dev-hub.example.com
 
-tela admin tokens add telad-staging-win01 -hub wss://staging-hub.example.com -token <staging-owner-token>
-# Save the printed token -- this is <agent-token> used in telad on staging-win01 (Step 3)
-
-# Grant each agent permission to register its machine
-tela admin access grant telad-dev-db01 dev-db01 register -hub wss://dev-hub.example.com -token <owner-token>
-
-# Create a developer token
-tela admin tokens add alice -hub wss://dev-hub.example.com -token <owner-token>
-# Save the printed token -- give it to Alice for use with tela connect (Step 4)
-tela admin access grant alice dev-db01 connect -hub wss://dev-hub.example.com -token <owner-token>
+# A developer
+tela admin tokens add alice -hub wss://dev-hub.example.com
+tela admin access grant alice dev-db01 connect -hub wss://dev-hub.example.com
+tela admin access grant alice dev-build connect -hub wss://dev-hub.example.com
 ```
 
-See [Run a hub on the public internet](../howto/hub.md) for the full list of `tela admin` commands.
+For the dev hub specifically, a wildcard connect grant
+(`tela admin access grant alice '*' connect`) is a defensible convenience:
+every developer reaches every dev machine, including ones added next month.
+Keep staging grants explicit, and production grants strictly explicit (see
+[Production Access](production-access.md)).
 
----
+**Onboarding** runs on pairing codes, not copied tokens. An admin runs
+`tela admin pair-code dev-db01` (or generates one from TelaVisor's Access
+tab), sends the short-lived code over chat, and the new hire runs the
+printed `tela pair` command. The permanent token lands directly in their
+credential store; nobody ever handles the raw value. See
+[Credentials and Pairing](../guide/credentials.md).
 
-## Step 3 - Register machines with `telad`
+**Offboarding** is `tela admin access remove <id>`, one command per hub.
 
-### Pattern A - Endpoint agents (recommended)
+## Shared Profiles
 
-Run `telad` on each machine you want to expose.
+Build one profile per environment with pinned `local:` ports and
+distribute the YAML file itself (it contains no secrets when tokens live in
+the credential store). Team members drop it into `~/.tela/profiles/`, or
+import it through TelaVisor's Profiles tab, and everyone's `dev-db` is on
+the same local port, which keeps connection strings in wikis and `.env`
+examples true for the whole team.
 
-Example (a Linux server exposing SSH and Postgres):
+Machine naming is part of the same discipline: stable role-based names
+(`staging-web02`, not an IP or a pet name) keep profiles, grants, and
+conversations unambiguous.
 
-```bash
-telad -hub wss://dev-hub.example.com -machine dev-db01 -ports "22,5432" -token <agent-token>
-```
+## Pitfalls Specific to This Scenario
 
-Example (a Windows staging box exposing RDP):
-
-```powershell
-telad.exe -hub wss://staging-hub.example.com -machine staging-win01 -ports "3389" -token <agent-token>
-```
-
-### Pattern B - Site gateway (bridge agent)
-
-Run `telad` on a gateway VM that can reach internal targets.
-
-Example `telad.yaml`:
-
-```yaml
-hub: wss://dev-hub.example.com
-token: "<agent-token>"
-machines:
-  - name: dev-db01
-    services:
-      - port: 22
-        name: SSH
-      - port: 5432
-        name: Postgres
-    target: 10.10.0.15
-  - name: dev-admin
-    services:
-      - port: 8443
-        name: Admin UI
-    target: 10.10.0.25
-```
-
-Run:
-
-```bash
-telad -config telad.yaml
-```
-
----
-
-## Step 4 - Developer workflow with `tela`
-
-On a developer laptop:
-
-1. Download `tela` from GitHub Releases and verify checksums.
-2. List machines:
-
-```bash
-tela machines -hub wss://dev-hub.example.com -token <your-token>
-```
-
-3. List services on a machine:
-
-```bash
-tela services -hub wss://dev-hub.example.com -machine dev-db01 -token <your-token>
-```
-
-4. Connect:
-
-```bash
-tela connect -hub wss://dev-hub.example.com -machine dev-db01 -token <your-token>
-```
-
-5. Use tools against the local address shown in the output:
-
-- SSH:
-
-```bash
-ssh -p PORT localhost
-```
-
-- Postgres (example):
-
-```bash
-psql -h localhost -p PORT -U postgres
-```
-
-**Tip:** Set environment variables to avoid repeating flags:
-
-```bash
-export TELA_HUB=wss://dev-hub.example.com
-export TELA_TOKEN=<your-token>
-tela machines
-tela connect -machine dev-db01
-```
-
----
-
-## Operational guidance
-
-### Naming conventions
-
-- Prefer stable names: `env-roleNN` (example: `staging-web02`).
-- Avoid embedding IPs in names.
-
-### Least privilege
-
-- Expose only required ports.
-- Prefer encrypted service protocols (SSH, TLS).
-
-### Split dev/staging/prod
-
-- Separate hubs are the simplest isolation boundary.
-
----
-
-## Troubleshooting
-
-### A machine is "online" but the service doesn't work
-
-- Endpoint pattern: verify the service is listening on that machine.
-- Gateway pattern: verify the gateway can reach `target:port`.
-
-### WebSocket blocked
-
-- If developers can't reach `wss://` due to corporate proxies, ensure the hub is accessible over standard HTTPS ports and that WebSockets are allowed.
+- Corporate networks and hotel Wi-Fi sometimes proxy or block WebSockets.
+  Publish the hub on standard HTTPS (port 443) behind a reverse proxy, per
+  [Run a Hub on the Public Internet](../howto/hub.md), and connections
+  survive almost any network a laptop lands on.
+- Do not share one identity across the team. Individual identities cost
+  nothing and are the difference between "revoke Bob" and "rotate the
+  token everyone uses and redistribute it."
+- If developers can list a machine but not connect, the machine grant is
+  missing; `tela admin access` shows the whole matrix at a glance.

--- a/book/src/use-cases/education-labs.md
+++ b/book/src/use-cases/education-labs.md
@@ -1,118 +1,83 @@
-# Education labs
+# Education Labs
 
-## The scenario
+A university computer lab has 30 workstations. Students need to reach their
+assigned machine from home for coursework: remote desktop, SSH, or a
+web-based IDE. The campus VPN is complex to set up, requires IT support for
+every student, and grants access to far more of the campus network than
+students should have.
 
-A university computer lab has 30 Linux workstations. Students need to connect to their assigned machine from home for coursework -- remote desktop, SSH, or a web-based IDE. The campus VPN is complex to set up, requires IT support for every student, and gives access to far more of the campus network than students should have.
-
-With Tela, each lab machine runs `telad` and registers with a lab-specific hub. Each student gets a token scoped to connect to their assigned machine only. Setup for a new student is a pairing code: they run one command to redeem it and they are ready to connect. An instructor token gives access to all machines in the lab for monitoring and support.
-
-From a student's laptop at home:
+With Tela, each lab machine runs `telad` and registers with a lab-specific
+hub. Each student gets access to their assigned machine only. Setup for a
+new student is a pairing code: one command to redeem it and they are ready
+to connect.
 
 ```
 Services available:
-  localhost:3389   → RDP          (lab-machine-07)
+  localhost:3389   → RDP          (lab-pc-07)
 ```
 
-They open Remote Desktop to that address and are on their lab machine. No VPN client. No campus IT ticket. No exposure to the rest of the campus network.
+They open Remote Desktop to that address and are on their lab machine. No
+VPN client, no campus IT ticket, no exposure to the rest of the campus
+network. At the end of the semester, the instructor removes the student
+identities in one pass; the lab machines stay registered for the next
+cohort.
 
-At the end of the semester, the instructor removes all student tokens in one pass. The lab machines stay registered for the next cohort.
+## Topology
 
-## Recommended topology
+One hub per lab or course keeps the blast radius and the roster equally
+small. The lab machines run endpoint agents as OS services, each exposing
+exactly one service (RDP for Windows labs, SSH for Linux labs, or the port
+of a web IDE). A shared agent identity across the lab machines is
+acceptable here; the machines are institutionally owned and identically
+managed, and it keeps imaging simple. Bake `telad` plus a `telad pair`
+step into the machine image and registration becomes part of provisioning.
 
-- **One hub per lab or course** (simple isolation)
-- `telad` on each lab machine (endpoint agent pattern)
+Deployment mechanics: [Run a Hub on the Public Internet](../howto/hub.md),
+[Run an Agent](../howto/telad.md),
+[Run Tela as an OS Service](../howto/services.md).
 
----
+## The Access Model
 
-## Step 1 - Deploy a hub for the lab
-
-1. Deploy the hub and publish it as `wss://lab-hub.example.com`.
-2. Verify hub console and `/api/status` are reachable.
-
-See [Run a hub on the public internet](../howto/hub.md) for the full hub deployment guide.
-
----
-
-## Step 2 - Enable authentication
-
-The hub prints an owner token on first start. Save it, then create identities for lab machines and students:
+The defining constraint is scoping: each student connects to their assigned
+machine and nothing else.
 
 ```bash
-# Create a shared agent token for lab machines
-tela admin tokens add lab-agent -hub wss://lab-hub.example.com -token <owner-token>
-# Save the printed token -- this is <lab-agent-token> used in telad on each lab machine (Step 3)
-
-# Grant the agent permission to register each machine
-tela admin access grant lab-agent lab-pc-017 register -hub wss://lab-hub.example.com -token <owner-token>
-tela admin access grant lab-agent lab-linux-03 register -hub wss://lab-hub.example.com -token <owner-token>
-
-# Create per-student tokens
-tela admin tokens add student-alice -hub wss://lab-hub.example.com -token <owner-token>
-# Save the printed token -- give it to Alice for use with tela connect (Step 4)
-tela admin access grant student-alice lab-pc-017 connect -hub wss://lab-hub.example.com -token <owner-token>
+tela admin tokens add student-alice -hub wss://lab-hub.example.com
+tela admin access grant student-alice lab-pc-07 connect -hub wss://lab-hub.example.com
 ```
 
-See [Run a hub on the public internet](../howto/hub.md) for the full list of `tela admin` commands.
-
----
-
-## Step 3 - Register lab machines
-
-On each lab machine, run `telad`.
-
-Example (Windows lab machine exposing RDP):
-
-```powershell
-telad.exe -hub wss://lab-hub.example.com -machine lab-pc-017 -ports "3389" -token <lab-agent-token>
-```
-
-Example (Linux lab machine exposing SSH):
+Onboard with pairing codes rather than raw tokens. A connect code scoped to
+one machine, generated per student, turns the first lab session into "run
+this one command":
 
 ```bash
-telad -hub wss://lab-hub.example.com -machine lab-linux-03 -ports "22" -token <lab-agent-token>
+tela admin pair-code lab-pc-07 -expires 7d
+# hand the printed 'tela pair' command to the student
 ```
 
-For persistent deployment, install `telad` as an OS service (see [Run Tela as an OS service](../howto/services.md)).
+The 7-day expiry covers add/drop week; unredeemed codes die on their own.
+An instructor identity gets a wildcard connect grant
+(`tela admin access grant instructor '*' connect`) for monitoring and
+support across all lab machines.
 
----
-
-## Step 4 - Student workflow
-
-On the student's machine:
-
-1. Download `tela`.
-2. List machines:
+At semester end, remove the cohort:
 
 ```bash
-tela machines -hub wss://lab-hub.example.com -token <student-token>
+tela admin access remove student-alice -hub wss://lab-hub.example.com
+# ... one per student; the machine registrations are untouched
 ```
 
-3. Connect to the assigned machine:
+The identity list on the hub is the roster; scripting the add and remove
+passes from the enrollment system is a natural next step.
 
-```bash
-tela connect -hub wss://lab-hub.example.com -machine lab-pc-017 -token <student-token>
-```
+## Pitfalls Specific to This Scenario
 
-4. Use the local address shown in the output. For RDP:
-
-```powershell
-mstsc /v:localhost:PORT
-```
-
----
-
-## Operational guidance
-
-- Pre-assign machine names to students.
-- Rotate credentials and policies each term.
-- Expose only RDP/VNC/SSH. Avoid granting broad internal network access.
-
----
-
-## Troubleshooting
-
-### Students can list machines but connect fails
-
-- Confirm the lab machine is online.
-- Confirm RDP/SSH is enabled and listening on the machine.
-- Ensure the lab hub URL supports WebSockets.
+- Student home networks are the wild west, but they only need outbound
+  HTTPS to the hub, which is precisely what home networks allow. Publish
+  the hub on port 443 behind TLS per the hub how-to.
+- RDP login is still campus-account authentication on the lab machine. A
+  student who cannot log in after connecting has an account problem, not a
+  Tela problem; the distinction saves support time.
+- Pre-assign machine names to students and use predictable names
+  (`lab-pc-07`). Grant mistakes with 30 near-identical machines are
+  otherwise inevitable.

--- a/book/src/use-cases/iot-edge.md
+++ b/book/src/use-cases/iot-edge.md
@@ -1,12 +1,18 @@
-# IoT and edge devices
+# IoT and Edge Devices
 
-## The scenario
+You have devices deployed in the field: Raspberry Pis running sensor
+software, kiosks at retail locations, industrial controllers at
+manufacturing sites, point-of-sale terminals at customer premises. These
+devices sit behind NATs and firewalls that you do not control and cannot
+configure. Getting SSH access to any of them today means coordinating with
+the site's IT team to open a port, shipping the device back, or driving
+out.
 
-You have devices deployed in the field: Raspberry Pis running sensor software, kiosks at retail locations, industrial controllers at manufacturing sites, point-of-sale terminals at customer premises. These devices sit behind NATs and firewalls that you do not control and cannot configure. Getting SSH access to any of them for maintenance currently requires coordinating with the site's IT team to open a port, or shipping the device back, or driving out.
-
-With Tela, each device runs `telad` and makes an outbound connection to a central hub. From that point, you can SSH into any registered device from your workstation without any firewall changes at the site. The hub never has access to the device's filesystem or credentials -- it only relays the encrypted tunnel.
-
-When you need to reach a device fleet, your workstation sees:
+With Tela, each device (or a small gateway at each site) runs `telad` and
+makes an outbound connection to a central hub. From then on you can reach
+any registered device from your workstation, with no firewall changes at
+the site. The hub never has access to the device's filesystem or
+credentials; it only relays the encrypted tunnel.
 
 ```
 Services available:
@@ -15,171 +21,83 @@ Services available:
   localhost:8080   → HTTP         (controller-plant-a)
 ```
 
-Devices that go offline (power loss, network interruption) reconnect automatically when they come back. You get consistent SSH access regardless of where a device is deployed or what the local network looks like.
+Devices that lose power or network reconnect automatically when they come
+back.
 
-## Choose a deployment pattern
+## Topology
 
-- **Pattern A (Endpoint agent)**: run `telad` on each device.
-- **Pattern B (Site gateway / bridge)**: run one `telad` at the customer site that can reach many devices.
+The endpoint-versus-gateway choice matters more here than in any other
+scenario:
 
-Pattern A is simplest per device. Pattern B reduces software footprint on devices but increases the importance of gateway hardening.
+- **An agent on each device** is simplest per device and survives site
+  network changes. It costs a `telad` process on hardware that may be
+  small; the agent is a single static binary with ARM builds, so a
+  Raspberry Pi class device handles it comfortably. Bake the binary and a
+  systemd unit into the device image
+  ([Run Tela as an OS Service](../howto/services.md)).
+- **A site gateway** (one `telad` fronting many devices at a location)
+  minimizes the footprint on devices that cannot run extra software, at
+  the price of making the gateway a critical asset. Put it in a dedicated
+  subnet, allowlist its egress to the hub URL only, and allowlist its
+  internal reach to exactly the target devices and ports:
 
----
+  ```yaml
+  hub: wss://hub.example.com
+  token: "<site-agent-token>"
+  machines:
+    - name: kiosk-001
+      target: 192.168.10.21
+      services:
+        - port: 22
+          name: SSH
+    - name: kiosk-002
+      target: 192.168.10.22
+      services:
+        - port: 22
+          name: SSH
+  ```
 
-## Step 1 - Run a hub reachable from anywhere
+Fleet-wide software management is where release channels earn their place:
+agents update themselves from a channel manifest, and you can point the
+fleet at a channel you control. See
+[Self-Update and Release Channels](../howto/channels.md).
 
-See [Run a hub on the public internet](../howto/hub.md) for the full deployment guide, including TLS and firewall setup. For a quick start on a host with a public address:
+## The Access Model
 
-```bash
-telahubd
-```
+The tradeoff to decide deliberately: per-device identities or a shared
+fleet identity.
 
-The hub prints an owner token on first start. Save it. Publish the hub as `wss://hub.example.com`.
+- **Per-device identities** give you per-device revocation: a device that
+  is stolen or tampered with can be cut off without touching the rest of
+  the fleet. The cost is provisioning: each device needs its own token or
+  register pairing code at imaging time.
+- **A shared fleet identity** is simpler to provision but means a
+  credential extracted from one compromised device is valid for the whole
+  fleet, and revoking it disconnects everything until re-provisioned.
 
----
+For devices in physically uncontrolled locations (retail kiosks, customer
+premises), per-device identities are worth the provisioning cost.
+Register-type pairing codes make it scriptable: mint one code per device
+(`tela admin pair-code kiosk-042 -type register -expires 7d`) and have the
+provisioning script run `telad pair`, so no long-lived credential ever
+sits in an image.
 
-## Step 2 - Set up authentication
+Operators get their own identities with connect grants, wildcard or scoped
+by region or customer, following the same rules as
+[Production Access](production-access.md).
 
-IoT devices on remote networks should always use authenticated connections:
+## Pitfalls Specific to This Scenario
 
-```bash
-# Create an agent token (one per device, or one shared identity)
-tela admin tokens add device-agent -hub wss://hub.example.com -token <owner-token>
-# Save the printed token -- this is <device-agent-token> used in telad.yaml on each device (Step 3)
-
-# Grant the agent permission to register each device
-tela admin access grant device-agent kiosk-001 register -hub wss://hub.example.com -token <owner-token>
-tela admin access grant device-agent kiosk-002 register -hub wss://hub.example.com -token <owner-token>
-
-# Create an operator token
-tela admin tokens add operator -hub wss://hub.example.com -token <owner-token>
-# Save the printed token -- this is <operator-token> used with tela connect (Step 5)
-tela admin access grant operator kiosk-001 connect -hub wss://hub.example.com -token <owner-token>
-tela admin access grant operator kiosk-002 connect -hub wss://hub.example.com -token <owner-token>
-```
-
-See [Run a hub on the public internet](../howto/hub.md) for the full list of `tela admin` commands.
-
----
-
-## Step 3 - Endpoint pattern: install and run `telad` on a device
-
-### 3.1 Install `telad`
-
-Download a prebuilt `telad` from GitHub Releases and copy the binary to the device.
-
-### 3.2 Create a minimal config
-
-Example `telad.yaml` on the device:
-
-```yaml
-hub: wss://hub.example.com
-token: "<device-agent-token>"
-machines:
-  - name: kiosk-001
-    services:
-      - port: 22
-        name: SSH
-    target: 127.0.0.1
-```
-
-Run:
-
-```bash
-telad -config telad.yaml
-```
-
-### 3.3 Run as a service (recommended)
-
-For persistent operation, install `telad` as a service:
-
-```bash
-telad service install -config telad.yaml
-telad service start
-```
-
-See [Run Tela as an OS service](../howto/services.md) for platform-specific details.
-
----
-
-## Step 4 - Site gateway pattern (bridge many devices)
-
-Run one gateway VM or device at the site. Configure one machine entry per target.
-
-Example `telad.yaml`:
-
-```yaml
-hub: wss://hub.example.com
-token: "<device-agent-token>"
-machines:
-  - name: kiosk-001
-    services:
-      - port: 22
-        name: SSH
-    target: 192.168.10.21
-  - name: kiosk-002
-    services:
-      - port: 22
-        name: SSH
-    target: 192.168.10.22
-```
-
-Run on the gateway:
-
-```bash
-telad -config telad.yaml
-```
-
-Hardening guidance for gateways:
-
-- Put the gateway in a dedicated subnet.
-- Allowlist only required egress (hub URL).
-- Allowlist only required internal targets and ports.
-
----
-
-## Step 5 - Operator workflow with `tela`
-
-From your laptop:
-
-1. Download `tela` from GitHub Releases and verify the checksum.
-2. List machines:
-
-```bash
-tela machines -hub wss://hub.example.com -token <operator-token>
-```
-
-3. Connect to a device:
-
-```bash
-tela connect -hub wss://hub.example.com -machine kiosk-001 -token <operator-token>
-```
-
-4. SSH to the address shown in the output:
-
-```bash
-ssh -p PORT localhost
-```
-
----
-
-## Troubleshooting
-
-### Device flaps online/offline
-
-- Check device power and network stability.
-- Check whether outbound HTTPS is allowed from the device.
-
-### `telad` logs "auth_required"
-
-- Check that the `token:` field is set in `telad.yaml` and the token is valid.
-- Verify the identity has been granted `register` access to the machine.
-
-### SSH connects but authentication fails
-
-- Tela is only the transport. SSH authentication is still handled by the device's SSH server.
-
-### Gateway can't reach targets
-
-- Confirm routing and firewall rules inside the site.
-- Validate `target` addresses from the gateway host itself.
+- **Flapping devices** (online, offline, online) are almost always power or
+  local network stability, not Tela; the agent's reconnect loop is doing
+  its job. Persistent absence usually means the site started blocking
+  outbound HTTPS, which is the one thing the device needs.
+- **SSH connects but authentication fails**: Tela is only the transport;
+  the device's SSH server still enforces its own keys and accounts.
+- **Cellular and metered links**: the idle control connection is
+  lightweight, but remember every remote session rides the site's uplink;
+  the UDP relay transport (hub port 41820) noticeably improves interactive
+  latency when the site allows outbound UDP.
+- Name devices by site and role (`kiosk-store-042`), and use the agent's
+  `tags` and `location` fields so a 500-device fleet stays filterable in
+  TelaVisor and portals.

--- a/book/src/use-cases/msp-it-support.md
+++ b/book/src/use-cases/msp-it-support.md
@@ -1,12 +1,16 @@
-# MSP and IT support
+# MSP and IT Support
 
-## The scenario
+You provide managed IT services or remote support to multiple customers.
+Each customer has Windows workstations and servers you need to reach for
+maintenance, troubleshooting, and remote desktop sessions. Today that means
+asking customers to open RDP to the internet, maintaining per-customer VPN
+configurations, or paying per-seat for a remote-access product.
 
-You provide managed IT services or remote support to multiple customers. Each customer has Windows workstations and servers you need to reach for maintenance, troubleshooting, and remote desktop sessions. Today, this means asking customers to open RDP to the internet, maintaining per-customer VPN configs, or using a paid remote-access product.
-
-With Tela, you deploy a small hub per customer (or per customer segment). An agent runs on each customer machine, making an outbound connection to the hub with no firewall changes on the customer's side. Your technicians connect through the hub using individual tokens -- so you know who accessed which machine and when, and revoking a departed technician's access takes one command.
-
-From a technician's workstation, connecting to a customer's machines looks like:
+With Tela, you run a small hub per customer. An agent on each customer
+machine makes an outbound connection to that hub, so nothing changes on the
+customer's firewall. Your technicians connect through the hub with
+individual tokens, which means you know who accessed which machine and
+when, and revoking a departed technician takes one command per hub.
 
 ```
 Services available:
@@ -15,138 +19,79 @@ Services available:
   localhost:22     → SSH          (acme-server-01)
 ```
 
-The customer's IT team does not need to configure anything on their firewall. The machines just work, from wherever the technician is.
+## Topology
 
-## Recommended topology
+**One hub per customer** is the recommended isolation model. Each customer
+gets its own hub (its own owner token, identity list, and history), so a
+compromise or misconfiguration at one customer cannot bleed into another,
+and offboarding a whole customer is decommissioning one hub. A single
+shared hub for many customers is possible but demands strict naming and
+much more careful grant hygiene; prefer isolation.
 
-For MSP-style support, there are two common models:
+Run the hubs on infrastructure you control, published at customer-specific
+URLs (`wss://acme-hub.example.com`), per
+[Run a Hub on the Public Internet](../howto/hub.md).
 
-1. **One hub per customer** (recommended isolation)
-2. **One hub for multiple customers** (requires careful naming and stricter access controls)
+On the customer side, two agent options:
 
-The steps below assume one hub per customer.
+- **An endpoint agent on each machine**, installed as an OS service. Expose
+  only what support needs: RDP on workstations, SSH on servers.
+- **A customer-site gateway** when you cannot install software on the
+  endpoints: one `telad` on a small box at the site, with a machine entry
+  per target (`target: 192.168.1.10`). The gateway box becomes critical
+  infrastructure; isolate it and allowlist its reachable targets.
 
----
+Register-type pairing codes make site onboarding scriptable: generate one
+per machine (`tela admin pair-code ws-01 -type register`), and the
+installation script at the customer site runs `telad pair` instead of
+embedding a long-lived token.
 
-## Step 1 - Deploy a hub for a customer
+## The Access Model
 
-1. Deploy the hub on infrastructure you control.
-2. Publish a customer-specific URL (example: `wss://acme-hub.example.com`).
-3. Ensure WebSockets work.
-
-See [Run a hub on the public internet](../howto/hub.md) for the full hub deployment guide, including TLS setup and firewall rules.
-
----
-
-## Step 2 - Set up authentication
-
-The hub prints an owner token on first start. Save it, then create identities for the customer's machines and your technicians:
-
-```bash
-# Create an agent token for the customer's machines
-tela admin tokens add acme-agent -hub wss://acme-hub.example.com -token <owner-token>
-# Save the printed token -- this is <agent-token> used in telad on each customer machine (Step 3)
-
-# Grant the agent permission to register each machine
-tela admin access grant acme-agent ws-01 register -hub wss://acme-hub.example.com -token <owner-token>
-tela admin access grant acme-agent srv-01 register -hub wss://acme-hub.example.com -token <owner-token>
-
-# Create technician tokens (one per technician so access can be revoked individually)
-tela admin tokens add tech-bob -hub wss://acme-hub.example.com -token <owner-token>
-# Save the printed token -- give it to Bob for use with tela connect (Step 4)
-tela admin access grant tech-bob ws-01 connect -hub wss://acme-hub.example.com -token <owner-token>
-tela admin access grant tech-bob srv-01 connect -hub wss://acme-hub.example.com -token <owner-token>
-```
-
-See [Run a hub on the public internet](../howto/hub.md) for the full list of `tela admin` commands.
-
----
-
-## Step 3 - Register customer machines
-
-### Pattern A - Endpoint agent (preferred)
-
-On each customer machine, run `telad` and expose only required ports.
-
-Example (Windows workstation, RDP only):
-
-```powershell
-telad.exe -hub wss://acme-hub.example.com -machine ws-01 -ports "3389" -token <agent-token>
-```
-
-Example (Linux server, SSH only):
+One identity per technician, per hub. Never a shared "support" token.
 
 ```bash
-telad -hub wss://acme-hub.example.com -machine srv-01 -ports "22" -token <agent-token>
+tela admin tokens add tech-bob -hub wss://acme-hub.example.com
+tela admin access grant tech-bob ws-01 connect -hub wss://acme-hub.example.com
+tela admin access grant tech-bob srv-01 connect -hub wss://acme-hub.example.com
 ```
 
-For persistent deployment, install `telad` as an OS service (see [Run Tela as an OS service](../howto/services.md)).
+For a technician who services everything at one customer, a wildcard
+connect grant on that customer's hub is reasonable; the hub boundary is
+already doing the isolation work. What individual identities buy you:
 
-### Pattern B - Customer-site gateway
+- The hub history attributes every session to a person, which is what a
+  customer asks for after an incident.
+- Offboarding a technician is `tela admin access remove tech-bob` on each
+  customer hub, and their access is gone everywhere it existed.
+- A leaked laptop is `tela admin rotate tech-bob`, not a fleet-wide
+  credential rollover.
 
-Use this when you can't install `telad` on individual endpoints. Run `telad` on a small gateway device that can reach internal targets, and configure one machine entry per target.
+Managing a dozen customer hubs from one screen is what TelaVisor's
+Infrastructure mode is for: every hub you hold credentials for appears in
+the Hubs and Agents tabs, and the Access tab edits any hub's grant matrix.
+For fleet-wide visibility beyond that, a portal aggregates all your hubs
+into one dashboard; see
+[Hub Directories and Portals](../guide/directories.md).
 
-Example `telad.yaml`:
+## The Technician Workflow
 
-```yaml
-hub: wss://acme-hub.example.com
-token: "<agent-token>"
-machines:
-  - name: ws-01
-    ports: [3389]
-    target: 192.168.1.10
-  - name: srv-01
-    ports: [22]
-    target: 192.168.1.20
-```
-
----
-
-## Step 4 - Technician workflow
-
-On the technician's machine:
-
-1. Download `tela` and verify the checksum.
-2. List machines:
+Technicians store one credential per customer hub (`tela login`), keep one
+profile per customer with pinned `local:` ports, and connect on demand:
 
 ```bash
-tela machines -hub wss://acme-hub.example.com -token <tech-token>
+tela connect -profile acme
+mstsc /v:localhost:3389        # acme-desktop-01
+mstsc /v:localhost:13389       # acme-desktop-02
 ```
 
-3. Connect:
+## Pitfalls Specific to This Scenario
 
-```bash
-tela connect -hub wss://acme-hub.example.com -machine ws-01 -token <tech-token>
-```
-
-4. Use the local address shown in the output. For RDP:
-
-```powershell
-mstsc /v:localhost:PORT
-```
-
----
-
-## Operational guidance
-
-- Use naming conventions (customer + role + number).
-- Expose only what you need.
-- Prefer encrypted service protocols.
-- Treat the gateway (if used) as critical infrastructure.
-
----
-
-## Troubleshooting
-
-### RDP opens but can't log in
-
-- Tela only transports TCP. Windows authentication policies still apply.
-
-### Endpoint agent can't connect out
-
-- Check the customer firewall allows outbound HTTPS.
-
-### `telad` logs "auth_required"
-
-- Check that the `-token` flag or `token:` config field is set and the token is valid.
-- Verify the identity has been granted `register` access to the machine.
+- Tela transports RDP; it does not authenticate it. Windows login policy,
+  NLA, and account lockout on the customer machines still apply and still
+  matter.
+- Customer sites with strict egress filtering need outbound HTTPS to your
+  hub URL allowed; that is the only network requirement on their side.
+- Keep a naming convention (`<customer>-<role><nn>`) even though hubs are
+  per-customer. Profiles, history entries, and support tickets all read
+  better for it.

--- a/book/src/use-cases/personal-cloud.md
+++ b/book/src/use-cases/personal-cloud.md
@@ -1,12 +1,15 @@
-# Personal cloud
+# Personal Cloud
 
-## The scenario
+You have several machines at home behind a residential router: a Network
+Attached Storage (NAS) device, a development workstation, a media server.
+The router performs NAT and you either cannot or do not want to open
+inbound ports. From a coffee shop or a corporate office, you currently have
+no way to reach any of them.
 
-You have several machines at home behind a residential router: a Network Attached Storage (NAS) device, a development workstation, a media server. Your router performs NAT and you either cannot or do not want to open inbound ports. From a coffee shop or a corporate office, you currently have no way to reach any of them.
-
-Tela solves this with a hub that lives on a small public VM (a $5/month server is plenty). Each home machine runs `telad`, which makes an outbound connection to the hub and registers itself. Your laptop runs `tela` and connects through the hub to whichever machine you need.
-
-When this is working, your laptop will have local ports for each home machine's services:
+Tela solves this with a hub on a small public VM (a $5/month server is
+plenty). Each home machine runs `telad`, which makes an outbound connection
+to the hub and registers itself. Your laptop runs `tela` and connects
+through the hub to whichever machine you need:
 
 ```
 Services available:
@@ -16,180 +19,87 @@ Services available:
   localhost:8096   → port 8096    (media server)
 ```
 
-Use the port shown in the output to connect. To pin a service to a specific local port across reconnects, set `local:` on that service in your profile.
+Nothing changes on your home router. No ports are forwarded. The home
+machines only make outbound connections.
 
-Nothing changes on your home router. No ports are forwarded. The home machines only make outbound connections.
+## Topology
 
-## Prerequisites
+One hub, one profile, a handful of machines. Two ways to run the agents:
 
-### Network and hosting
+- **An agent on each machine** (the endpoint pattern) is the default
+  choice. Each machine registers itself and exposes its own services.
+- **One gateway agent for the house** works when some machines cannot run
+  `telad` (an appliance NAS, a smart device). Run `telad` on one
+  always-on box and give it a machine entry per target with a `target:`
+  LAN address. See the gateway pattern in [Run an Agent](../howto/telad.md).
 
-- A machine to run the hub (Linux VM, home server, or any host that can accept inbound HTTPS or is reachable via a reverse proxy).
-- A public URL for the hub (recommended). Tela works best when the hub is reachable via `wss://`.
+Setup mechanics are covered once, in the how-tos:
+[Run a Hub on the Public Internet](../howto/hub.md) for the hub,
+[Run an Agent](../howto/telad.md) for each machine, and
+[Run Tela as an OS Service](../howto/services.md) so everything survives
+reboots.
 
-### Software
+## The Access Model
 
-- Hub: the `telahubd` binary.
-- Agent: the `telad` binary (run on endpoints or a gateway).
-- Client: the `tela` binary.
-
----
-
-## Step 1 - Run a hub
-
-See [Run a hub on the public internet](../howto/hub.md) for the full deployment walkthrough, including TLS configuration and service installation. For a quick test on a host with a public address:
-
-```bash
-telahubd
-```
-
-The hub prints an owner token on first start. Save it. It listens on port 80 (HTTP + WebSocket) and 41820 (UDP relay) by default.
-
----
-
-## Step 2 - Set up authentication
-
-Create tokens for each agent and user:
+Even for a single user, do not run everything on the owner token. Create
+one agent identity with register permission per machine, and one user
+identity for yourself with connect permission on all machines:
 
 ```bash
-# Agent token (one per machine that will register with the hub)
-tela admin tokens add barn-agent -hub wss://hub.example.com -token <owner-token>
-# Save the printed token -- this is <agent-token> used in telad (Step 3)
+tela admin tokens add workstation-agent -hub wss://hub.example.com
+tela admin access grant workstation-agent workstation register -hub wss://hub.example.com
 
-# Grant the agent permission to register its machine
-tela admin access grant barn-agent barn register -hub wss://hub.example.com -token <owner-token>
-
-# User token (for the person connecting from client machines)
-tela admin tokens add alice -hub wss://hub.example.com -token <owner-token>
-# Save the printed token -- this is <your-token> used with tela connect (Step 4)
-tela admin access grant alice barn connect -hub wss://hub.example.com -token <owner-token>
+tela admin tokens add me -hub wss://hub.example.com
+tela admin access grant me '*' connect -hub wss://hub.example.com
 ```
 
-See [Run a hub on the public internet](../howto/hub.md) for the full list of `tela admin` commands.
+The wildcard grant covers machines you add later, so onboarding a new home
+machine never requires touching your own token. Store your token once with
+`tela login` and forget about `-token` flags.
 
----
+## One Profile for the Whole House
 
-## Step 3 - Register a home machine (choose a pattern)
-
-### Pattern A - Run `telad` on the home machine (recommended)
-
-Use this when you can run `telad` directly on the machine that hosts the services.
-
-1. Decide which services to expose (common examples):
-   - SSH (22)
-   - RDP (3389)
-   - HTTP admin UI (8080, 8443, etc.)
-
-2. Start `telad`:
-
-```bash
-telad -hub wss://hub.example.com -machine barn -ports "22,3389" -token <agent-token>
-```
-
-3. Verify from another machine:
-
-```bash
-tela machines -hub wss://hub.example.com -token <your-token>
-tela services -hub wss://hub.example.com -machine barn -token <your-token>
-```
-
-Notes:
-
-- For persistent access, prefer a config file and run `telad` as a service.
-- Keep service exposure minimal: only the ports you need.
-- The token must be a valid agent token with `register` access to the machine.
-
-### Pattern B - Run `telad` on a gateway that can reach the home machines
-
-Use this when the target machine is locked down or you want to minimize installed software on the target.
-
-1. Put the gateway on the same network as the target(s).
-2. Configure one machine entry per target:
+A single connection profile opens tunnels to every machine at once, and
+explicit `local:` ports keep the layout stable when two machines expose the
+same service:
 
 ```yaml
-hub: wss://hub.example.com
-token: "<agent-token>"
-machines:
-  - name: nas
+# ~/.tela/profiles/home.yaml
+connections:
+  - hub: wss://hub.example.com
+    machine: workstation
     services:
-      - port: 22
-        name: SSH
-    target: 192.168.1.50
+      - remote: 22
+  - hub: wss://hub.example.com
+    machine: nas
+    services:
+      - remote: 22
+        local: 10022
+      - remote: 5000
+  - hub: wss://hub.example.com
+    machine: media
+    services:
+      - remote: 8096
 ```
 
-3. Start `telad` with the config file:
+Two additions earn their keep in this scenario:
 
-```bash
-telad -config telad.yaml
-```
+- **File shares.** Enable a share on the NAS
+  ([File Sharing](../guide/file-sharing.md)) and add a `mount:` block to
+  the profile so the share appears as a drive letter whenever you connect.
+- **DNS names.** `tela dns hosts` gives every machine a stable name
+  (`ssh nas.tela`), which beats memorizing which fallback port the NAS
+  landed on. See [Connection Profiles](../guide/profiles.md#dns-names).
 
----
+## Pitfalls Specific to This Scenario
 
-## Step 4 - Connect from a client machine
-
-On the machine you're connecting from:
-
-1. Download `tela` from the latest GitHub Release.
-2. List machines:
-
-```bash
-tela machines -hub wss://hub.example.com -token <your-token>
-```
-
-3. Connect:
-
-```bash
-tela connect -hub wss://hub.example.com -machine barn -token <your-token>
-```
-
-The client prints the local address bound for each service. Use that address to connect.
-
----
-
-## Step 5 - Use the service (SSH / RDP)
-
-### SSH
-
-After `tela connect`:
-
-```bash
-ssh -p PORT localhost
-```
-
-Use the port shown in the `tela connect` output.
-
-### RDP (Windows)
-
-After `tela connect`:
-
-```powershell
-mstsc /v:localhost:PORT
-```
-
-Use the port shown in the `tela connect` output.
-
----
-
-## Security notes
-
-- Tela provides end-to-end encryption for tunneled traffic (hub relays ciphertext).
-- The last hop from `telad` to the service is plain TCP unless the service protocol is encrypted (SSH, HTTPS, etc.).
-  - Endpoint pattern keeps last hop local to the machine.
-  - Gateway pattern puts last hop on your LAN; use segmentation and strong service authentication.
-- Expose only the ports you actually need.
-
----
-
-## Troubleshooting
-
-### I can't see my machine in `tela machines`
-
-- Confirm `telad` is running and connecting to the correct hub URL.
-- Check the hub console at `/` to see if the machine shows up.
-- Confirm the hub is reachable from the agent host (outbound HTTPS/WebSocket allowed).
-- If auth is enabled, confirm the agent token is valid and has been granted `register` access to the machine.
-
-### `tela` connects but SSH/RDP fails
-
-- Confirm the target service is listening on the target machine.
-- If using gateway pattern, confirm the gateway can reach the target IP and port.
+- The last hop from `telad` to the service is plain TCP. On the endpoint
+  pattern that hop never leaves the machine; on the gateway pattern it
+  crosses your LAN, so prefer services with their own encryption (SSH,
+  HTTPS) for anything sensitive.
+- Expose only the ports you actually use. A NAS admin UI you touch twice a
+  year can stay unexposed until you need it; adding a service later is one
+  line of YAML and a `telad` restart.
+- If a machine never appears in `tela machines`, check the agent's outbound
+  path to the hub first; residential networks rarely block it, but
+  guest-network isolation can.

--- a/book/src/use-cases/private-web-app.md
+++ b/book/src/use-cases/private-web-app.md
@@ -1,259 +1,117 @@
-# Private web application
+# Private Web Application
 
-## The scenario
+You are running a web application that should not be reachable from the
+open internet: an internal admin panel, a staging environment, a team
+dashboard, or a self-hosted tool like Grafana, Gitea, or Outline. Today it
+either lives behind a VPN (complex to onboard users), has IP allowlisting
+(fragile when team members move around), or is simply exposed with a long
+URL and a hope that nobody finds it.
 
-You are running a web application that should not be reachable from the open internet. It might be an internal admin panel, a staging environment, a team dashboard, or a self-hosted tool like Grafana, Gitea, or Outline. Right now it either lives behind a VPN (complex to onboard users), has IP allowlisting (fragile when team members work from different locations), or is simply exposed to the public internet with a long URL and a hope that nobody finds it.
-
-With Tela, the application server runs `telad` with a path gateway configured. The gateway exposes a single tunnel port that routes HTTP requests by URL prefix to the right local service. The server has no inbound firewall rule. Users who have been explicitly granted access connect through the hub and get a local address in their browser:
+With Tela, the application server runs `telad` with a path gateway
+configured. The server has no inbound firewall rule. Users who have been
+explicitly granted access connect through the hub and open a local address
+in their browser:
 
 ```
 Services available:
   localhost:8080   → HTTP
 ```
 
-They open `http://localhost:8080/` in a browser. The connection travels through an end-to-end encrypted WireGuard tunnel to the application server. The hub relays ciphertext and cannot see request or response content. Users without a valid token cannot reach the machine at all -- there is nothing to find, because the server never accepted an inbound connection from them.
+The connection travels through an end-to-end encrypted WireGuard tunnel to
+the application server. The hub relays ciphertext and cannot see request or
+response content. Users without a valid token cannot reach the machine at
+all; there is nothing to find, because the server never accepts an inbound
+connection from them.
 
-If the application has multiple services (a frontend, an API, a metrics endpoint), the gateway routes each URL prefix to the right local port, so the browser sees everything as the same origin and Cross-Origin Resource Sharing (CORS) issues do not arise.
+## Topology
 
-## How it works
-
-`telad` runs on the application server and registers the machine with the hub.
-It exposes the web application through its built-in path gateway -- a single
-tunnel port that routes HTTP requests to local services by URL prefix. Only
-users whose tokens have been granted `connect` permission on that machine can
-reach anything at all. The hub relays ciphertext; it cannot see request or
-response content.
-
-When a user connects, `tela` binds a local address (for example,
-`localhost:8080`). The user opens that address in a browser. The connection
-travels through the encrypted WireGuard tunnel to the application server, where
-`telad` forwards it to the local service. No inbound firewall rule is needed on
-the application server.
-
----
-
-## Step 1 - Stand up a hub
-
-See [Run a hub on the public internet](../howto/hub.md) for the full
-deployment guide. For a quick start:
-
-```bash
-telahubd
-```
-
-The hub prints an owner token on first start. Save it. Publish the hub as
-`wss://hub.example.com`.
-
----
-
-## Step 2 - Set up authentication
-
-Create a token for the agent and one token per user:
-
-```bash
-# Create an agent token for the application server
-tela admin tokens add app-agent -hub wss://hub.example.com -token <owner-token>
-# Save the printed token -- this is <app-agent-token> used in telad.yaml (Step 3)
-
-# Grant the agent permission to register the machine
-tela admin access grant app-agent myapp register -hub wss://hub.example.com -token <owner-token>
-
-# Create user tokens (one per person)
-tela admin tokens add alice -hub wss://hub.example.com -token <owner-token>
-# Save Alice's printed token -- give it to Alice to use with tela connect or tela login
-tela admin tokens add bob -hub wss://hub.example.com -token <owner-token>
-# Save Bob's printed token -- give it to Bob
-
-# Grant each user connect access to the machine
-tela admin access grant alice myapp connect -hub wss://hub.example.com -token <owner-token>
-tela admin access grant bob myapp connect -hub wss://hub.example.com -token <owner-token>
-```
-
-Users without an explicit `connect` grant cannot reach the machine even if they
-hold a valid hub token.
-
----
-
-## Step 3 - Configure and run `telad` on the application server
-
-Because `telad` uses userspace networking, the gateway can listen on port 80
-inside the tunnel without elevated privileges on either the server or the
-user's machine. Users browse to `http://localhost/` with no port number.
-
-### Single-service application
-
-If the application runs on one local port (for example, port 3000), route
-it through the gateway on port 80:
+One hub, one agent on the application server, one gateway exposing the app.
+The gateway is the load-bearing piece: it routes URL path prefixes to local
+ports, so a frontend, an API, and an admin panel all appear as one origin
+in the browser and Cross-Origin Resource Sharing (CORS) never comes up.
 
 ```yaml
-# telad.yaml
+# telad.yaml on the application server
 hub: wss://hub.example.com
 token: "<app-agent-token>"
 
 machines:
   - name: myapp
     gateway:
-      port: 80
+      port: 8080
       routes:
-        - path: /
-          target: 3000    # application's local port
-```
-
-```bash
-telad -config telad.yaml
-```
-
-Users connect and open `http://localhost/` in a browser.
-
-### Multi-service application
-
-If the application has separate frontend and backend processes -- a common
-arrangement for single-page applications -- route them by path:
-
-```yaml
-# telad.yaml
-hub: wss://hub.example.com
-token: "<app-agent-token>"
-
-machines:
-  - name: myapp
-    gateway:
-      port: 80
-      routes:
+        - path: /admin/
+          target: 5000    # admin panel
         - path: /api/
           target: 4000    # REST API
         - path: /
-          target: 3000    # frontend (SPA or server-rendered)
+          target: 3000    # frontend
 ```
 
-Requests to `/api/...` are forwarded to the local API process on port 4000.
-Everything else goes to the frontend on port 3000. Both local ports are
-invisible outside the server. The browser sees a single origin, so no
-Cross-Origin Resource Sharing (CORS) configuration is needed.
+The local ports 3000, 4000, and 5000 are invisible outside the server.
+Routes match by longest prefix regardless of their order in the file. For
+the mechanics (hub deployment, agent service install, gateway
+verification), see [Run a Hub on the Public Internet](../howto/hub.md),
+[Run an Agent](../howto/telad.md), and
+[Set Up a Path-Based Gateway](../howto/gateway.md).
 
-To add an admin panel at a separate path:
+## The Access Model
 
-```yaml
-gateway:
-  port: 80
-  routes:
-    - path: /admin/
-      target: 5000    # admin panel
-    - path: /api/
-      target: 4000    # REST API
-    - path: /
-      target: 3000    # frontend
-```
-
-Routes are matched by longest prefix first, regardless of their order in the
-file.
-
-For persistent operation, install `telad` as a service:
+This scenario is where per-user identities pay off. One agent identity for
+the server, one identity per person, each with a connect grant on the one
+machine:
 
 ```bash
-telad service install -config telad.yaml
-telad service start
+tela admin tokens add app-agent -hub wss://hub.example.com
+tela admin access grant app-agent myapp register -hub wss://hub.example.com
+
+tela admin tokens add alice -hub wss://hub.example.com
+tela admin access grant alice myapp connect -hub wss://hub.example.com
 ```
 
-See [Run Tela as an OS service](../howto/services.md) for platform-specific
-details.
+A user holding a valid hub token but no connect grant on `myapp` still
+cannot reach it. To onboard someone without shuttling a raw token around,
+generate a pairing code instead
+(`tela admin pair-code myapp`; see
+[Credentials and Pairing](../guide/credentials.md)).
 
----
+Revocation is one command, effective immediately, and terminates any active
+session from that token:
 
-## Step 4 - User workflow
+```bash
+tela admin access revoke alice myapp -hub wss://hub.example.com   # this machine only
+tela admin access remove alice -hub wss://hub.example.com          # identity gone entirely
+```
 
-On each user's machine:
+## The User's Side
 
-1. Download `tela`.
-2. Store the hub token so it does not need to be passed on every command:
+Each user stores their token once, then connects with a profile:
 
 ```bash
 tela login wss://hub.example.com
-# Prompts for token
-```
-
-3. Connect:
-
-```bash
 tela connect -hub wss://hub.example.com -machine myapp
 ```
 
-4. Open the address shown in the output in a browser:
+They open `http://localhost:8080/` in a browser. A profile with
+`services: [{name: gateway}]` makes it a one-command habit; export the
+profile file and hand it to new users so nobody has to build it by hand.
 
-```
-http://localhost/
-```
+Keep the gateway on a port like 8080 rather than 80. The client binds the
+gateway's port on the user's own machine, and binding port 80 on Linux and
+macOS requires elevated privileges, which defeats one of Tela's design
+points; a client that cannot bind it will silently land on the 10080
+fallback instead.
 
-### Connection profile (optional)
+## Pitfalls Specific to This Scenario
 
-If users connect to this application regularly, a profile avoids repeating
-flags:
-
-```yaml
-# ~/.tela/profiles/myapp.yaml
-connections:
-  - hub: wss://hub.example.com
-    token: ${MYAPP_TOKEN}
-    machine: myapp
-    services:
-      - name: gateway
-```
-
-```bash
-tela connect -profile myapp
-```
-
-Set `MYAPP_TOKEN` in the environment, or omit the `token` field if the token
-is already in the credential store.
-
----
-
-## Revoking access
-
-To revoke a specific user's access:
-
-```bash
-# Remove connect permission for this machine only
-tela admin access revoke alice myapp -hub wss://hub.example.com -token <owner-token>
-
-# Or remove the identity entirely (disconnects immediately, deletes all permissions)
-tela admin access remove alice -hub wss://hub.example.com -token <owner-token>
-```
-
-Revocation takes effect immediately. Any active session from that token is
-terminated.
-
----
-
-## Troubleshooting
-
-### Browser shows "connection refused"
-
-- Confirm the application is running on the server and listening on the
-  expected local port.
-- Confirm `telad` is running and the machine is online (`tela machines -hub
-  wss://hub.example.com`).
-- For gateway setups, confirm the `target` port in `telad.yaml` matches the
-  port the application actually listens on.
-
-### User can connect but gets a 404 on all paths
-
-- The gateway route for `/` may be missing. Add a catch-all route with
-  `path: /` pointing at the frontend service.
-- Confirm the frontend process is running and reachable from the server
-  itself (for example, `curl http://localhost:3000/`).
-
-### Browser loads the page but API calls fail
-
-- In a gateway setup, the API route path must match the path prefix the
-  frontend uses for its requests. If the frontend calls `/api/v1/users`, the
-  route must be `path: /api/` or `path: /api/v1/`.
-- The gateway does not proxy WebSocket connections. If the application uses
-  WebSockets for the API, expose the WebSocket service as a separate named
-  service alongside the gateway.
-
-### `tela connect` is refused ("auth_required" or 403)
-
-- Confirm the user's token has been granted `connect` access:
-  `tela admin access -hub wss://hub.example.com -token <owner-token>`
-- Confirm the token is stored correctly: `tela login wss://hub.example.com`.
+- **404 on every path** usually means the catch-all `path: /` route is
+  missing.
+- **The page loads but API calls fail**: the route prefix must match what
+  the frontend actually requests. If the frontend calls `/api/v1/users`,
+  either `path: /api/` or `path: /api/v1/` works; `path: /api` without the
+  trailing slash is the classic typo.
+- **The app uses WebSockets** (live dashboards often do): if it misbehaves
+  behind the gateway, expose that service directly as a named TCP service
+  alongside the gateway and point the app at its own port.
+- Application-level authentication is still the application's job. Tela
+  controls who can reach the app, not who can log into it.

--- a/book/src/use-cases/production-access.md
+++ b/book/src/use-cases/production-access.md
@@ -1,12 +1,17 @@
-# Production access
+# Production Access
 
-## The scenario
+Your production infrastructure runs on cloud VMs or bare metal with no
+inbound ports open. Today, getting to a machine requires a bastion host, a
+VPN, or punching a hole in the firewall. All of those need ongoing
+maintenance, invite shared-credential problems, and usually end up granting
+broader access than intended ("connect to the VPN, now you can reach
+everything").
 
-Your production infrastructure runs on cloud VMs or bare metal with no inbound ports open. Today, getting to a machine requires a bastion host, a VPN, or punching a hole in the firewall. Any of those approaches requires ongoing maintenance, introduces a shared-credential problem, and often ends up with broader access than intended ("connect to the VPN, now you can reach everything").
-
-With Tela, each production VM runs `telad` as an OS service. It makes an outbound connection to a dedicated production hub and registers itself, exposing only the specific ports the team needs -- SSH, a database port, an admin panel. Access is controlled per-machine and per-identity: the on-call engineer has SSH access to the web servers, the DBA has database access, neither has access to the other's machines.
-
-When a team member needs to connect, they run `tela connect` with their profile. They get a local address for each machine they have access to:
+With Tela, each production VM runs `telad` as an OS service, makes an
+outbound connection to a dedicated production hub, and exposes only the
+specific ports the team needs. Access is per-machine and per-identity: the
+on-call engineer has SSH to the web servers, the DBA has the database port,
+and neither has the other's access.
 
 ```
 Services available:
@@ -15,170 +20,83 @@ Services available:
   localhost:5432   → port 5432    (db-01)
 ```
 
-No bastion. No VPN. No shared credentials. If a team member leaves, their identity is removed from the hub and their access ends immediately -- nothing else changes on the production machines.
+No bastion. No VPN. No shared credentials. When a team member leaves, their
+identity is removed from the hub and their access ends immediately; nothing
+changes on the production machines.
 
-## Strong recommendation for production
+## Topology
 
-- Prefer **Pattern A (Endpoint agent)** on each production VM.
-- Expose the smallest possible set of services.
-- Use a dedicated hub for production.
-- Always enable authentication. Treat hub and agent tokens as secrets.
+- **A dedicated hub per environment.** Separate hubs for production and
+  staging are the simplest possible control boundary: different owner
+  tokens, different identity lists, no way to cross by accident. Deploy the
+  production hub with TLS and a service manager per
+  [Run a Hub on the Public Internet](../howto/hub.md).
+- **An endpoint agent on every VM**, installed as an OS service
+  ([Run an Agent](../howto/telad.md),
+  [Run Tela as an OS Service](../howto/services.md)). Use the gateway
+  pattern only for machines that genuinely cannot run `telad`, and treat
+  any such gateway host as critical infrastructure: isolated, and
+  allowlisted to specific targets and ports.
+- **Minimal exposure.** A web server exposes port 22. A database server
+  exposes 22 and 5432. Nothing exposes a port range.
 
----
+## The Access Model
 
-## Step 1 - Stand up a production hub
-
-See [Run a hub on the public internet](../howto/hub.md) for the full deployment guide, including TLS setup with a reverse proxy and cloud firewall rules. For a quick start on hardened infrastructure:
-
-```bash
-telahubd
-```
-
-The hub prints an owner token on first start. Save it. Publish the hub as `wss://prod-hub.example.com`.
-
-Verify:
-- HTTPS/TLS is valid
-- WebSockets work
-- `/api/status` is reachable
-
----
-
-## Step 2 - Set up authentication
-
-Create tokens for each production machine and each operator:
+One agent identity per machine, one operator identity per human, grants
+that mirror actual responsibilities:
 
 ```bash
-# Create agent tokens (one per production machine)
-tela admin tokens add agent-web01 -hub wss://prod-hub.example.com -token <owner-token>
-# Save the printed token -- this is <agent-web01-token> used in telad on prod-web01 (Step 3)
-tela admin tokens add agent-db01 -hub wss://prod-hub.example.com -token <owner-token>
-# Save the printed token -- this is <agent-db01-token> used in telad on prod-db01 (Step 3)
+# Agents: one identity per VM, register permission on its own machine only
+tela admin tokens add agent-web01 -hub wss://prod-hub.example.com
+tela admin access grant agent-web01 prod-web01 register -hub wss://prod-hub.example.com
 
-# Grant each agent permission to register its machine
-tela admin access grant agent-web01 prod-web01 register -hub wss://prod-hub.example.com -token <owner-token>
-tela admin access grant agent-db01 prod-db01 register -hub wss://prod-hub.example.com -token <owner-token>
-
-# Create operator tokens
-tela admin tokens add alice -hub wss://prod-hub.example.com -token <owner-token>
-# Save the printed token -- give it to Alice for use with tela connect (Step 4)
-tela admin access grant alice prod-web01 connect -hub wss://prod-hub.example.com -token <owner-token>
-tela admin access grant alice prod-db01 connect -hub wss://prod-hub.example.com -token <owner-token>
+# Operators: connect grants per machine, per person
+tela admin tokens add alice -hub wss://prod-hub.example.com
+tela admin access grant alice prod-web01 connect -hub wss://prod-hub.example.com
+tela admin access grant alice prod-db01 connect -hub wss://prod-hub.example.com
 ```
 
-See [Run a hub on the public internet](../howto/hub.md) for the full list of `tela admin` commands.
+Two production-grade refinements:
 
----
+- **Per-service grants.** When a machine exposes several services, a
+  connect grant can be narrowed to named services, so the DBA reaches
+  PostgreSQL but not SSH:
 
-## Step 3 - Register production machines with `telad`
+  ```bash
+  tela admin access grant dba prod-db01 connect -services postgres -hub wss://prod-hub.example.com
+  ```
 
-### Pattern A - Endpoint agent
+- **Rotation and audit.** Rotate any credential you suspect with
+  `tela admin rotate <id>` (the old token dies instantly, permissions
+  survive), and review recent session events with the hub's history
+  (`/api/history`, the hub console, or TelaVisor's History view).
 
-On each production VM, run `telad` with a config file:
+## The Operator Workflow
 
-```yaml
-# telad.yaml
-hub: wss://prod-hub.example.com
-token: "<agent-web01-token>"
-
-machines:
-  - name: prod-web01
-    ports: [22]
-```
+Operators store their token once (`tela login wss://prod-hub.example.com`),
+keep a profile per environment with pinned `local:` ports, and connect on
+demand:
 
 ```bash
-telad -config telad.yaml
+tela connect -profile prod
+ssh -p 22 localhost          # web-01, per the profile's port layout
+psql -h localhost -p 5432 -U postgres
 ```
 
-Or with flags (quick start):
+Pinned local ports matter more here than anywhere else: muscle memory and
+shell history should never depend on which fallback port a machine happened
+to get.
 
-```bash
-telad -hub wss://prod-hub.example.com -machine prod-web01 -ports "22" -token <agent-token>
-```
+## Pitfalls Specific to This Scenario
 
-For persistent operation, install as a service:
-
-```bash
-telad service install -config telad.yaml
-telad service start
-```
-
-See [Run Tela as an OS service](../howto/services.md) for platform-specific details.
-
-Guidance:
-
-- If you need database access, require TLS on the database itself.
-- Avoid exposing wide port ranges.
-
-### Pattern B - Gateway/bridge agent (use sparingly)
-
-Use only when endpoints cannot run `telad`. The gateway becomes a critical asset: it must be isolated and tightly allowlisted to specific targets and ports.
-
----
-
-## Step 4 - Operator workflow
-
-On an operator machine:
-
-1. Download `tela` and verify the checksum.
-2. List machines:
-
-```bash
-tela machines -hub wss://prod-hub.example.com -token <your-token>
-```
-
-3. Connect to a machine:
-
-```bash
-tela connect -hub wss://prod-hub.example.com -machine prod-web01 -token <your-token>
-```
-
-4. Use tools against the local address shown in the output:
-
-- SSH:
-
-```bash
-ssh -p PORT localhost
-```
-
-- Database (example):
-
-```bash
-psql -h localhost -p PORT -U postgres
-```
-
-**Tip:** Set environment variables to avoid repeating flags:
-
-```bash
-export TELA_HUB=wss://prod-hub.example.com
-export TELA_TOKEN=<your-token>
-tela machines
-tela connect -machine prod-web01
-```
-
----
-
-## Security notes (production)
-
-- Tela encrypts the tunnel end-to-end; the hub relays ciphertext.
-- Production hardening is still necessary:
-  - Patch systems
-  - Strong SSH authentication
-  - Least privilege -- grant `connect` access only to the machines each operator needs
-  - Audit access -- check `/api/history` on the hub
-  - Rotate tokens periodically -- use `tela admin rotate`
-- Separate hubs per environment are the simplest control boundary.
-
----
-
-## Troubleshooting
-
-### Operators can reach hub but no machines appear
-
-- Confirm `telad` is running on the production VM.
-- Confirm egress from the VM allows outbound HTTPS/WebSockets to the hub.
-- If auth is enabled, confirm the agent token is valid and has been granted `register` access to the machine.
-
-### Service reachable locally on the server but not via Tela
-
-- Confirm the service is listed by `tela services -hub <hub> -machine <machine> -token <token>`.
-- Confirm the correct port is exposed in `telad`.
+- Tela moves the network perimeter; it does not replace host hardening.
+  Patching, strong SSH authentication, and TLS on the database itself all
+  still apply. The hop from `telad` to the local service is plain TCP, so
+  services that carry credentials should bring their own encryption.
+- Verify egress: production VMs with strict outbound firewalls need to
+  allow the WebSocket connection to the hub (and, optionally, UDP to the
+  hub's relay port).
+- Resist the temptation to grant `'*'` connect to operators "for now."
+  Wildcards are for the personal-cloud scenario; in production the
+  per-machine grant list is the audit trail of who was supposed to reach
+  what.


### PR DESCRIPTION
## What This Is

A full editorial pass over `book/src` (40 files, net -270 lines) to make the book read as one coherent, edited work rather than chapters accreted by different models at different times, and to bring every factual claim back in line with the code. Card: tela-74.

## Factual Corrections (verified against code)

- **Loopback binding story corrected book-wide.** `tela connect` binds `127.0.0.1` at the service's local port with a +10000 fallback (`internal/client/client.go` `bindLocal`); the deterministic `127.88.x.y` addresses exist only for `tela dns hosts`. Several chapters and Appendix A conflated the two; the profile `address:` field is now documented as a dns-hosts override, not a bind pin.
- **Glossary "Upstream" entry rewritten.** It described a multi-hub alias feature that does not exist; upstreams are TCP dependency-forwarding rules (`internal/agent/upstream.go`).
- **Pair codes**: default expiry is 10 minutes (not 24h as guide/admin.md claimed), max 7 days, custom `d`-suffix parsing confirmed.
- **Viewer role**: cannot be chosen at token creation but can be set via role change; both halves now stated correctly.
- **Console auth**: removed the `?token=<admin-token>` instruction (deprecated, S1) and the "last 200 events" claim (ring buffer holds 100).
- **TelaVisor platforms**: glossary claimed Windows-only; release.yml builds Windows installer, Linux .deb/.rpm/binary, macOS .app tarball.
- **Mgmt actions list** in architecture/remote-admin.md extended to the full current set (update-status, update-channel, channel-sources-*).
- **Service-scoped grants** (`-services` flag) added to the Hub Administration chapter.
- **telaportal** added to the directories chapter as the first-party self-hosted portal option.
- Stale version examples (v0.4-v0.13) normalized to the current series.

## Structural Changes

- **Use cases rewritten** (all seven): the identical hub/auth/agent/connect skeleton repeated per chapter is gone; each is now a scenario-specific chapter covering topology choice, access model, and scenario pitfalls, pointing at the how-tos for mechanics.
- **howto/gateway.md** rewritten as a true walkthrough; it previously duplicated ~70% of guide/gateway.md.
- **telad.md / services.md** and **installation.md / channels.md** deduplicated along the same lines.
- **ops/roadmap.md and ops/status.md** added to SUMMARY.md (they existed but were orphaned).
- **release-process.md** trimmed: branches-that-are-only-bookkeeping section, telachand history, and the pre-0.12 bootstrap narrative cut; the 401-vs-404 endpoint check kept as a pitfall.
- Style rules enforced across all files: Title Case headings at every level, no em-dash or spaced-hyphen stand-ins, no curly quotes.

## Verification

- `mdbook build` (v0.4.40 + mdbook-mermaid, same versions as docs.yml) builds clean; all `{{#include}}` targets expand.
- All relative links in `book/src` resolve (scripted check).
- Zero em-dashes, curly quotes, or spaced-hyphen dashes outside Mermaid edge syntax.

## Flags for the Operator (not changed in this PR)

1. **Gateway WebSocket claim**: three chapters asserted the path gateway "does not proxy WebSockets," but the implementation is a plain `httputil.ReverseProxy`, which passes upgrades through since Go 1.12. I removed the definitive negative claim and advise direct exposure only as a fallback. Worth a quick live test and then a firm statement either way.
2. **Console admin elevation is dead code**: the console always injects the viewer token and its JS always sends it as the Bearer header, so the Pairing card can never appear on an authenticated hub (`internal/hub/hub.go:996-1020`, `console/www/index.html:1140-1155`). The book no longer documents an elevation path; the console defect itself needs a card.
3. **`fileShare:` legacy shim still exists in code** (`internal/agent/fileshare.go:245-271`) despite the pre-1.0 no-shims policy; I removed it from the book. Deleting the shim needs a card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)