### PR TITLE
fix: Synchronize Package Globals Against Teststack Teardown Races

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -46,6 +46,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -357,11 +358,76 @@ type registration struct {
 	Gateway               *gatewayConfig
 }
 
-var verbose bool
+// verbose is set from the -v flag and read from many goroutines, so it is
+// an atomic to stay race-free against the teststack reset. tunnelMTU is
+// deliberately left bare: it is written only during Main() flag parsing and
+// read on the session path, never touched by ResetForTesting (card tela-79).
+var verbose atomic.Bool
 var tunnelMTU = defaultMTU
 
-// stopCh is closed to signal graceful shutdown (used in service mode).
-var stopCh chan struct{}
+// stopCh is closed to signal graceful shutdown (used in service mode). All
+// access is routed through stopMu and the helpers below so the teststack
+// teardown (ResetForTesting) can run concurrently with in-flight reconnect
+// and shutdown goroutines without a data race (card tela-79). A nil channel
+// blocks forever in a select, which is the intended shutdown-not-armed state.
+var (
+	stopMu       sync.RWMutex
+	stopCh       chan struct{}
+	stopChClosed bool
+)
+
+// stopChan returns the current stop channel under a read lock. A nil return
+// blocks forever in a select, exactly like reading a nil global directly.
+func stopChan() chan struct{} {
+	stopMu.RLock()
+	defer stopMu.RUnlock()
+	return stopCh
+}
+
+// newStopCh unconditionally installs a fresh stop channel and returns it.
+// Used by the entry points that own the shutdown lifecycle (Main and the
+// service runners).
+func newStopCh() chan struct{} {
+	stopMu.Lock()
+	defer stopMu.Unlock()
+	stopCh = make(chan struct{})
+	stopChClosed = false
+	return stopCh
+}
+
+// ensureStopCh installs a fresh stop channel only when none is set and
+// returns the current channel. It closes the check-then-assign TOCTOU window
+// that the plain accessors cannot express against a concurrent reset.
+func ensureStopCh() chan struct{} {
+	stopMu.Lock()
+	defer stopMu.Unlock()
+	if stopCh == nil {
+		stopCh = make(chan struct{})
+		stopChClosed = false
+	}
+	return stopCh
+}
+
+// closeStopCh closes the current stop channel if it is set and not already
+// closed. The closed flag under the same lock keeps the single-closer
+// contract intact and makes a double close a no-op instead of a panic, which
+// replaces the ad-hoc select-default guards the bridge goroutines used.
+func closeStopCh() {
+	stopMu.Lock()
+	defer stopMu.Unlock()
+	if stopCh != nil && !stopChClosed {
+		close(stopCh)
+		stopChClosed = true
+	}
+}
+
+// clearStopCh drops the stop channel reference. Used only by ResetForTesting.
+func clearStopCh() {
+	stopMu.Lock()
+	defer stopMu.Unlock()
+	stopCh = nil
+	stopChClosed = false
+}
 
 // ── Log ring buffer ───────────────────────────────────────────────
 
@@ -435,8 +501,9 @@ func setActiveConfig(cfg *configFile, path string) {
 // handleMgmtRequest processes a management message from the hub and
 // returns a JSON response to send back.
 // reregisterNeeded is set by config-set to signal runAgent to
-// send an updated registration to the hub with the new metadata.
-var reregisterNeeded bool
+// send an updated registration to the hub with the new metadata. It is an
+// atomic so the reset can clear it while runAgent reads it (card tela-79).
+var reregisterNeeded atomic.Bool
 
 func handleMgmtRequest(lg *log.Logger, msg *controlMessage) []byte {
 	ok := true
@@ -573,7 +640,7 @@ func handleMgmtRequest(lg *log.Logger, msg *controlMessage) []byte {
 		}
 
 		lg.Printf("mgmt: config-set machine=%s (requestId=%s)", update.Machine, msg.RequestID)
-		reregisterNeeded = true
+		reregisterNeeded.Store(true)
 		resp, _ := json.Marshal(controlMessage{
 			Type: "mgmt-response", RequestID: msg.RequestID, OK: &ok,
 		})
@@ -1189,8 +1256,9 @@ func Main() {
 	portsStr := flag.String("ports", envOrDefault("TELAD_PORTS", ""), "Comma-separated port specs: port[:name[:description]]  e.g. 22:SSH,3389:RDP,12345:MyApp (env: TELAD_PORTS)")
 	targetHost := flag.String("target-host", envOrDefault("TELAD_TARGET_HOST", "127.0.0.1"), "Target service host (env: TELAD_TARGET_HOST)")
 	mtuOverride := flag.Int("mtu", 0, "WireGuard tunnel MTU (env: TELAD_MTU; default 1100)")
-	flag.BoolVar(&verbose, "v", false, "Verbose logging")
+	verboseFlag := flag.Bool("v", false, "Verbose logging")
 	flag.Parse()
+	verbose.Store(*verboseFlag)
 
 	// Resolve MTU: flag > env > default
 	if *mtuOverride > 0 {
@@ -1204,13 +1272,13 @@ func Main() {
 	telelog.Init("telad", &logRingWriter{original: os.Stderr})
 
 	// Handle graceful shutdown
-	stopCh = make(chan struct{})
+	newStopCh()
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		<-sigCh
 		log.Println("shutting down")
-		close(stopCh)
+		closeStopCh()
 	}()
 
 	// Config-file mode
@@ -1599,10 +1667,10 @@ func serviceStatus() {
 func serviceRunDaemon(svcStop <-chan struct{}) {
 	// Bridge service stop channel to the global stopCh so
 	// runSingleMachine exits its reconnect loop on shutdown.
-	stopCh = make(chan struct{})
+	newStopCh()
 	go func() {
 		<-svcStop
-		close(stopCh)
+		closeStopCh()
 	}()
 
 	// When running as a Windows service, redirect log output to a file.
@@ -1687,10 +1755,10 @@ func serviceRun() {
 // serviceRunUserDaemon is the user-mode variant of serviceRunDaemon.
 // It loads config from the user directory instead of the system directory.
 func serviceRunUserDaemon(svcStop <-chan struct{}) {
-	stopCh = make(chan struct{})
+	newStopCh()
 	go func() {
 		<-svcStop
-		close(stopCh)
+		closeStopCh()
 	}()
 
 	logDest := io.Writer(os.Stderr)
@@ -1809,19 +1877,13 @@ func Run(ctx context.Context, cfg *Config) error {
 	// Bridge ctx cancellation to the package-level stopCh that the
 	// per-machine reconnect loops watch. This is the same channel
 	// Main() and serviceRunDaemon() set up; we just plumb a context in.
-	if stopCh == nil {
-		stopCh = make(chan struct{})
-	}
+	// ensureStopCh installs one only if a lifecycle owner has not already,
+	// and closeStopCh is idempotent under the lock, so no defensive
+	// select-default sentinel is needed here.
+	ensureStopCh()
 	go func() {
 		<-ctx.Done()
-		// Close defensively -- close on an already-closed channel
-		// would panic, so we use a select-with-default sentinel.
-		select {
-		case <-stopCh:
-			// already closed
-		default:
-			close(stopCh)
-		}
+		closeStopCh()
 	}()
 	runMultiMachine(cfg, "")
 	return nil
@@ -1932,7 +1994,7 @@ func runSingleMachine(hubURL string, reg registration, targetHost string) {
 
 		// Check for shutdown before reconnecting
 		select {
-		case <-stopCh:
+		case <-stopChan():
 			logger.Printf("shutdown received, exiting reconnect loop")
 			return
 		default:
@@ -1944,7 +2006,7 @@ func runSingleMachine(hubURL string, reg registration, targetHost string) {
 		// Wait for delay or shutdown, whichever comes first
 		select {
 		case <-time.After(delay):
-		case <-stopCh:
+		case <-stopChan():
 			logger.Printf("shutdown received, exiting reconnect loop")
 			return
 		}
@@ -2089,7 +2151,7 @@ func runAgent(lg *log.Logger, hubURL string, reg registration, targetHost string
 	// ReadMessage loop below unblocks promptly instead of waiting for
 	// the pong timeout.
 	go func() {
-		<-stopCh
+		<-stopChan()
 		ws.Close()
 	}()
 
@@ -2188,8 +2250,8 @@ func runAgent(lg *log.Logger, hubURL string, reg registration, targetHost string
 				lg.Printf("mgmt-response write failed: %v", err)
 			}
 			// If config changed, re-register with the hub to push updated metadata
-			if reregisterNeeded {
-				reregisterNeeded = false
+			if reregisterNeeded.Load() {
+				reregisterNeeded.Store(false)
 				activeConfigMu.RLock()
 				cfg := activeConfig
 				activeConfigMu.RUnlock()
@@ -2327,7 +2389,7 @@ func handleSession(lg *log.Logger, ws *websocket.Conn, hubURL, helperPubKeyHex, 
 
 	// Create WireGuard device
 	wgVerbose := silentLogger{}.Printf
-	if verbose {
+	if verbose.Load() {
 		wgVerbose = lg.Printf
 	}
 	logger := &device.Logger{
@@ -2761,7 +2823,7 @@ func wsToHTTP(wsURL string) string {
 }
 
 func logVerbose(lg *log.Logger, format string, args ...any) {
-	if verbose {
+	if verbose.Load() {
 		lg.Printf(format, args...)
 	}
 }
@@ -2779,15 +2841,21 @@ func envOrDefault(key, fallback string) string {
 // the agent (active config, stop channel, reregister flag, verbose
 // flag) so the next test run starts from a clean slate. Tests call
 // this in t.Cleanup. Production code never calls it.
+//
+// Every field it touches is accessed only through a synchronized accessor
+// or an atomic, mirroring internal/hub.ResetForTesting, so this can run
+// concurrently with stragglers the teststack SkipLeakCheck configurations
+// tolerate without a data race (card tela-79). agent tunnelMTU is not reset:
+// it is written only during Main() flag parsing and is read-only here.
 func ResetForTesting() {
 	activeConfigMu.Lock()
 	activeConfig = nil
 	activeConfigPath = ""
 	activeConfigMu.Unlock()
 
-	// Drain stopCh if it was closed by a previous Run; tests will
+	// Drop stopCh if it was closed by a previous Run; tests will
 	// recreate it on the next Run() call.
-	stopCh = nil
-	reregisterNeeded = false
-	verbose = false
+	clearStopCh()
+	reregisterNeeded.Store(false)
+	verbose.Store(false)
 }

--- a/internal/agent/reset_race_test.go
+++ b/internal/agent/reset_race_test.go
@@ -1,0 +1,59 @@
+package agent
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestResetForTestingConcurrentAccess drives the agent's package-level
+// globals from many reader goroutines while ResetForTesting runs on the
+// main goroutine. It gives the teststack teardown race fixed in card
+// tela-79 a deterministic trigger under the -race detector: before the
+// fix the bare stopCh, verbose, and reregisterNeeded globals raced with
+// the reset; after it every access goes through a synchronized accessor
+// or an atomic. The test asserts nothing beyond the absence of a panic
+// or a -race failure, so it also passes cleanly without -race.
+func TestResetForTestingConcurrentAccess(t *testing.T) {
+	const readers = 8
+	const iterations = 500
+
+	// Arm a stop channel so the readers observe a live value to start.
+	newStopCh()
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < readers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				// Touch every global the reset mutates.
+				select {
+				case <-stopChan():
+				default:
+				}
+				_ = verbose.Load()
+				_ = reregisterNeeded.Load()
+			}
+		}()
+	}
+
+	for i := 0; i < iterations; i++ {
+		ResetForTesting()
+		newStopCh()
+		ensureStopCh()
+		verbose.Store(i%2 == 0)
+		reregisterNeeded.Store(i%2 == 1)
+	}
+
+	close(stop)
+	wg.Wait()
+
+	// Leave the package globals in the clean post-reset state.
+	ResetForTesting()
+}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -55,6 +55,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"text/tabwriter"
 	"time"
@@ -129,11 +130,79 @@ var portNames = map[uint16]string{
 	5900: "VNC", 8080: "HTTP", 8443: "HTTPS",
 }
 
-var verbose bool
-var tunnelMTU = defaultMTU
+// verbose and tunnelMTU are package globals that ResetForTesting clears, so
+// both are synchronized (atomics) to stay race-free against the teststack
+// teardown while in-flight session goroutines still read them (card tela-79).
+var verbose atomic.Bool
+var tunnelMTU atomic.Int32
 
-// stopCh is closed to signal graceful shutdown (used in service mode).
-var stopCh chan struct{}
+func init() {
+	tunnelMTU.Store(defaultMTU)
+}
+
+// stopCh is closed to signal graceful shutdown (used in service mode). All
+// access is routed through stopMu and the helpers below so the teststack
+// teardown (ResetForTesting) can run concurrently with in-flight reconnect
+// and session goroutines without a data race (card tela-79). A nil channel
+// blocks forever in a select, which is the intended shutdown-not-armed state.
+var (
+	stopMu       sync.RWMutex
+	stopCh       chan struct{}
+	stopChClosed bool
+)
+
+// stopChan returns the current stop channel under a read lock. A nil return
+// blocks forever in a select, exactly like reading a nil global directly.
+func stopChan() chan struct{} {
+	stopMu.RLock()
+	defer stopMu.RUnlock()
+	return stopCh
+}
+
+// newStopCh unconditionally installs a fresh stop channel and returns it.
+// Used by the entry points that own the shutdown lifecycle (Main and the
+// service runners).
+func newStopCh() chan struct{} {
+	stopMu.Lock()
+	defer stopMu.Unlock()
+	stopCh = make(chan struct{})
+	stopChClosed = false
+	return stopCh
+}
+
+// ensureStopCh installs a fresh stop channel only when none is set and
+// returns the current channel. It closes the check-then-assign TOCTOU window
+// that the plain accessors cannot express against a concurrent reset.
+func ensureStopCh() chan struct{} {
+	stopMu.Lock()
+	defer stopMu.Unlock()
+	if stopCh == nil {
+		stopCh = make(chan struct{})
+		stopChClosed = false
+	}
+	return stopCh
+}
+
+// closeStopCh closes the current stop channel if it is set and not already
+// closed. The closed flag under the same lock keeps the single-closer
+// contract intact and makes a double close a no-op instead of a panic, which
+// replaces the ad-hoc select-default guards the bridge goroutines used.
+func closeStopCh() {
+	stopMu.Lock()
+	defer stopMu.Unlock()
+	if stopCh != nil && !stopChClosed {
+		close(stopCh)
+		stopChClosed = true
+	}
+}
+
+// clearStopCh drops the stop channel reference. Used only by ResetForTesting.
+func clearStopCh() {
+	stopMu.Lock()
+	defer stopMu.Unlock()
+	stopCh = nil
+	stopChClosed = false
+}
 
 // Main is the entry point for the tela client binary. The cmd/tela
 // shim calls this; tests do not -- they call Connect() directly with
@@ -304,15 +373,16 @@ func cmdConnect(args []string) {
 	localPort := fs.Int("port", 0, "Local TCP port (legacy; prefer -ports)")
 	targetPort := fs.Int("target-port", 0, "Target port on daemon (legacy; with -port)")
 	mtuOverride := fs.Int("mtu", 0, "WireGuard tunnel MTU (env: TELA_MTU; default 1100)")
-	fs.BoolVar(&verbose, "v", false, "Verbose logging")
+	verboseFlag := fs.Bool("v", false, "Verbose logging")
 	fs.Parse(args)
+	verbose.Store(*verboseFlag)
 
 	// Resolve MTU: flag > env > default
 	if *mtuOverride > 0 {
-		tunnelMTU = *mtuOverride
+		tunnelMTU.Store(int32(*mtuOverride))
 	} else if v := os.Getenv("TELA_MTU"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
-			tunnelMTU = n
+			tunnelMTU.Store(int32(n))
 		}
 	}
 
@@ -341,13 +411,13 @@ func cmdConnect(args []string) {
 		os.Exit(1)
 	}
 
-	stopCh = make(chan struct{})
+	newStopCh()
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		<-sigCh
 		log.Println("shutting down")
-		close(stopCh)
+		closeStopCh()
 	}()
 
 	// Create persistent listeners that survive session reconnects.
@@ -356,7 +426,7 @@ func cmdConnect(args []string) {
 	var bridge *tunnelBridge
 	if len(mappings) > 0 {
 		bridge = newTunnelBridge()
-		closeListeners := bindPersistentListeners(mappings, *machineID, *hubURL, bridge, stopCh)
+		closeListeners := bindPersistentListeners(mappings, *machineID, *hubURL, bridge, stopChan())
 		defer closeListeners()
 	}
 
@@ -373,7 +443,7 @@ func cmdConnect(args []string) {
 
 		// Check for shutdown before reconnecting
 		select {
-		case <-stopCh:
+		case <-stopChan():
 			return
 		default:
 		}
@@ -384,7 +454,7 @@ func cmdConnect(args []string) {
 		// Wait for delay or shutdown, whichever comes first
 		select {
 		case <-time.After(delay):
-		case <-stopCh:
+		case <-stopChan():
 			return
 		}
 		attempt++
@@ -435,7 +505,7 @@ func Connect(ctx context.Context, opts ConnectOptions) error {
 		opts.Token = credstore.LookupToken(opts.HubURL)
 	}
 	if opts.Verbose {
-		verbose = true
+		verbose.Store(true)
 	}
 
 	// Convert exported PortMapping to the internal portMapping type.
@@ -449,24 +519,20 @@ func Connect(ctx context.Context, opts ConnectOptions) error {
 
 	// Bridge ctx -> the package-level stopCh that runSession and the
 	// listener loop watch. This is the same channel cmdConnect sets up
-	// from a signal handler; we just plumb a context in.
-	if stopCh == nil {
-		stopCh = make(chan struct{})
-	}
+	// from a signal handler; we just plumb a context in. ensureStopCh
+	// installs one only if a lifecycle owner has not already, and
+	// closeStopCh is idempotent under the lock, so no defensive
+	// select-default sentinel is needed here.
+	ensureStopCh()
 	go func() {
 		<-ctx.Done()
-		select {
-		case <-stopCh:
-			// already closed
-		default:
-			close(stopCh)
-		}
+		closeStopCh()
 	}()
 
 	var bridge *tunnelBridge
 	if len(mappings) > 0 {
 		bridge = newTunnelBridge()
-		closeListeners := bindPersistentListeners(mappings, opts.MachineID, opts.HubURL, bridge, stopCh)
+		closeListeners := bindPersistentListeners(mappings, opts.MachineID, opts.HubURL, bridge, stopChan())
 		defer closeListeners()
 	}
 
@@ -482,7 +548,7 @@ func Connect(ctx context.Context, opts ConnectOptions) error {
 		}
 
 		select {
-		case <-stopCh:
+		case <-stopChan():
 			return nil
 		default:
 		}
@@ -492,7 +558,7 @@ func Connect(ctx context.Context, opts ConnectOptions) error {
 
 		select {
 		case <-time.After(delay):
-		case <-stopCh:
+		case <-stopChan():
 			return nil
 		}
 		attempt++
@@ -502,10 +568,15 @@ func Connect(ctx context.Context, opts ConnectOptions) error {
 // ResetForTesting wipes the package-level mutable state used by the
 // client (stopCh, verbose flag, MTU override). Tests call this from
 // teststack so consecutive runs do not see each other's state.
+//
+// Every field it touches is accessed only through a synchronized accessor
+// or an atomic, mirroring internal/hub.ResetForTesting, so this can run
+// concurrently with stragglers the teststack SkipLeakCheck configurations
+// tolerate without a data race (card tela-79).
 func ResetForTesting() {
-	stopCh = nil
-	verbose = false
-	tunnelMTU = defaultMTU
+	clearStopCh()
+	verbose.Store(false)
+	tunnelMTU.Store(defaultMTU)
 }
 
 // ── Port/service mapping helpers ────────────────────────────────────
@@ -809,23 +880,23 @@ func runProfile(name string) {
 
 	// Apply profile-level MTU if set
 	if profile.MTU > 0 {
-		tunnelMTU = profile.MTU
+		tunnelMTU.Store(int32(profile.MTU))
 	}
 
 	// Only initialize stopCh if not already set (service mode sets it externally).
-	if stopCh == nil {
-		stopCh = make(chan struct{})
+	if stopChan() == nil {
+		newStopCh()
 		sigCh := make(chan os.Signal, 1)
 		signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 		go func() {
 			<-sigCh
 			log.Println("shutting down all connections")
-			close(stopCh)
+			closeStopCh()
 		}()
 	}
 
 	// Start the control API server for this profile.
-	cleanupControl := startControlServer(name, stopCh)
+	cleanupControl := startControlServer(name, stopChan())
 	defer cleanupControl()
 
 	log.Printf("loaded profile with %d connection(s)", len(profile.Connections))
@@ -843,7 +914,7 @@ func runProfile(name string) {
 		go func() {
 			select {
 			case <-time.After(2 * time.Second):
-			case <-stopCh:
+			case <-stopChan():
 				return
 			}
 			if err := validateMountPoint(mc.Mount); err != nil {
@@ -950,7 +1021,7 @@ func runProfile(name string) {
 					}
 					log.Printf("[profile:%d] %v", idx, err)
 					select {
-					case <-stopCh:
+					case <-stopChan():
 						log.Printf("[profile:%d] shutdown during service resolution", idx)
 						return
 					default:
@@ -959,7 +1030,7 @@ func runProfile(name string) {
 					log.Printf("[profile:%d] retrying service resolution in %s...", idx, delay.Round(time.Second))
 					select {
 					case <-time.After(delay):
-					case <-stopCh:
+					case <-stopChan():
 						return
 					}
 					resolveAttempt++
@@ -969,7 +1040,7 @@ func runProfile(name string) {
 			var bridge *tunnelBridge
 			if len(maps) > 0 {
 				bridge = newTunnelBridge()
-				closeListeners := bindPersistentListeners(maps, mach, hub, bridge, stopCh)
+				closeListeners := bindPersistentListeners(maps, mach, hub, bridge, stopChan())
 				defer closeListeners()
 			}
 
@@ -987,7 +1058,7 @@ func runProfile(name string) {
 
 				// Check for shutdown before reconnecting
 				select {
-				case <-stopCh:
+				case <-stopChan():
 					log.Printf("[profile:%d] shutdown received", idx)
 					return
 				default:
@@ -999,7 +1070,7 @@ func runProfile(name string) {
 				// Wait for delay or shutdown, whichever comes first
 				select {
 				case <-time.After(delay):
-				case <-stopCh:
+				case <-stopChan():
 					log.Printf("[profile:%d] shutdown received", idx)
 					return
 				}
@@ -1938,7 +2009,7 @@ func runSession(hubURL, machineID, token string, overrideMappings []portMapping,
 	tunDev, tnet, err := netstack.CreateNetTUN(
 		[]netip.Addr{netip.MustParseAddr(sessionHelperIP)},
 		nil, // no DNS
-		tunnelMTU,
+		int(tunnelMTU.Load()),
 	)
 	if err != nil {
 		log.Printf("netstack creation failed: %v", err)
@@ -1950,7 +2021,7 @@ func runSession(hubURL, machineID, token string, overrideMappings []portMapping,
 
 	// Create WireGuard device
 	wgVerbose := func(string, ...any) {}
-	if verbose {
+	if verbose.Load() {
 		wgVerbose = log.Printf
 	}
 	logger := &device.Logger{
@@ -2041,7 +2112,7 @@ persistent_keepalive_interval=25
 	if bridge != nil || len(overrideMappings) == 0 {
 		select {
 		case <-done:
-		case <-stopCh:
+		case <-stopChan():
 			wsConn.Close()
 			<-done
 		}
@@ -2107,7 +2178,7 @@ persistent_keepalive_interval=25
 
 	select {
 	case <-done:
-	case <-stopCh:
+	case <-stopChan():
 		wsConn.Close()
 		<-done
 	}
@@ -2340,7 +2411,7 @@ func tryDirectUpgrade(bind *wsbind.Bind, hubURL string) {
 }
 
 func logVerbose(format string, args ...any) {
-	if verbose {
+	if verbose.Load() {
 		log.Printf(format, args...)
 	}
 }
@@ -2608,10 +2679,10 @@ func serviceStatus() {
 func serviceRunDaemon(svcStop <-chan struct{}) {
 	// Bridge service stop channel to the global stopCh so
 	// reconnect loops exit on shutdown.
-	stopCh = make(chan struct{})
+	newStopCh()
 	go func() {
 		<-svcStop
-		close(stopCh)
+		closeStopCh()
 	}()
 
 	telelog.Init("tela", os.Stderr)
@@ -2666,7 +2737,7 @@ func serviceRunDaemon(svcStop <-chan struct{}) {
 			var bridge *tunnelBridge
 			if len(maps) > 0 {
 				bridge = newTunnelBridge()
-				closeListeners := bindPersistentListeners(maps, mach, hub, bridge, stopCh)
+				closeListeners := bindPersistentListeners(maps, mach, hub, bridge, stopChan())
 				defer closeListeners()
 			}
 
@@ -2683,7 +2754,7 @@ func serviceRunDaemon(svcStop <-chan struct{}) {
 				}
 
 				select {
-				case <-stopCh:
+				case <-stopChan():
 					log.Printf("[svc:%d] shutdown received", idx)
 					return
 				default:
@@ -2694,7 +2765,7 @@ func serviceRunDaemon(svcStop <-chan struct{}) {
 
 				select {
 				case <-time.After(delay):
-				case <-stopCh:
+				case <-stopChan():
 					log.Printf("[svc:%d] shutdown received", idx)
 					return
 				}
@@ -2730,10 +2801,10 @@ func serviceRun() {
 // serviceRunUserDaemon is the user-mode variant of serviceRunDaemon.
 // It loads config from the user directory instead of the system directory.
 func serviceRunUserDaemon(svcStop <-chan struct{}) {
-	stopCh = make(chan struct{})
+	newStopCh()
 	go func() {
 		<-svcStop
-		close(stopCh)
+		closeStopCh()
 	}()
 
 	telelog.Init("tela", os.Stderr)
@@ -2789,7 +2860,7 @@ func serviceRunUserDaemon(svcStop <-chan struct{}) {
 			var bridge *tunnelBridge
 			if len(maps) > 0 {
 				bridge = newTunnelBridge()
-				closeListeners := bindPersistentListeners(maps, mach, hub, bridge, stopCh)
+				closeListeners := bindPersistentListeners(maps, mach, hub, bridge, stopChan())
 				defer closeListeners()
 			}
 
@@ -2802,7 +2873,7 @@ func serviceRunUserDaemon(svcStop <-chan struct{}) {
 					return
 				}
 				select {
-				case <-stopCh:
+				case <-stopChan():
 					return
 				default:
 				}
@@ -2810,7 +2881,7 @@ func serviceRunUserDaemon(svcStop <-chan struct{}) {
 				log.Printf("[svc:%d] reconnecting in %s...", idx, delay.Round(time.Second))
 				select {
 				case <-time.After(delay):
-				case <-stopCh:
+				case <-stopChan():
 					return
 				}
 				attempt++

--- a/internal/client/control.go
+++ b/internal/client/control.go
@@ -318,7 +318,7 @@ func startControlServer(profileName string, stopCh chan struct{}) func() {
 				time.Sleep(100 * time.Millisecond)
 				log.Println("[control] shutdown requested via control API")
 				log.Println("shutting down all connections")
-				close(stopCh)
+				closeStopCh()
 			}()
 
 		default:

--- a/internal/client/control.go
+++ b/internal/client/control.go
@@ -387,11 +387,12 @@ func startControlServer(profileName string, stopCh chan struct{}) func() {
 		}
 		switch r.Method {
 		case http.MethodGet:
-			writeJSON(w, http.StatusOK, map[string]bool{"verbose": verbose})
+			writeJSON(w, http.StatusOK, map[string]bool{"verbose": verbose.Load()})
 		case http.MethodPut:
-			verbose = !verbose
-			log.Printf("[control] verbose logging %s", map[bool]string{true: "enabled", false: "disabled"}[verbose])
-			writeJSON(w, http.StatusOK, map[string]bool{"verbose": verbose})
+			newVerbose := !verbose.Load()
+			verbose.Store(newVerbose)
+			log.Printf("[control] verbose logging %s", map[bool]string{true: "enabled", false: "disabled"}[newVerbose])
+			writeJSON(w, http.StatusOK, map[string]bool{"verbose": newVerbose})
 		default:
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		}
@@ -599,18 +600,18 @@ func startControlServer(profileName string, stopCh chan struct{}) func() {
 			case "disconnect":
 				log.Println("[control] disconnect requested via WebSocket")
 				log.Println("shutting down all connections")
-				close(stopCh)
+				closeStopCh()
 			case "reconnect":
 				log.Println("[control] reconnect requested via WebSocket")
 				// Placeholder: reconnect logic can be wired up later.
 			case "set_verbose":
 				if cmd.Enabled != nil {
-					verbose = *cmd.Enabled
+					verbose.Store(*cmd.Enabled)
 				} else {
-					verbose = !verbose
+					verbose.Store(!verbose.Load())
 				}
 				log.Printf("[control] verbose logging %s (via WebSocket)",
-					map[bool]string{true: "enabled", false: "disabled"}[verbose])
+					map[bool]string{true: "enabled", false: "disabled"}[verbose.Load()])
 			}
 		}
 		// Reader exited; clean up.

--- a/internal/client/reset_race_test.go
+++ b/internal/client/reset_race_test.go
@@ -1,0 +1,61 @@
+package client
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestResetForTestingConcurrentAccess drives the client's package-level
+// globals from many reader goroutines while ResetForTesting runs on the
+// main goroutine. It gives the teststack teardown race fixed in card
+// tela-79 a deterministic trigger under the -race detector: before the
+// fix the bare stopCh, verbose, and tunnelMTU globals raced with the
+// reset (the client.Connect reconnect-loop read at client.go was the
+// exact site in the captured race report). After the fix every access
+// goes through a synchronized accessor or an atomic. The test asserts
+// nothing beyond the absence of a panic or a -race failure, so it also
+// passes cleanly without -race.
+func TestResetForTestingConcurrentAccess(t *testing.T) {
+	const readers = 8
+	const iterations = 500
+
+	// Arm a stop channel so the readers observe a live value to start.
+	newStopCh()
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < readers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				// Touch every global the reset mutates.
+				select {
+				case <-stopChan():
+				default:
+				}
+				_ = verbose.Load()
+				_ = tunnelMTU.Load()
+			}
+		}()
+	}
+
+	for i := 0; i < iterations; i++ {
+		ResetForTesting()
+		newStopCh()
+		ensureStopCh()
+		verbose.Store(i%2 == 0)
+		tunnelMTU.Store(int32(1000 + i))
+	}
+
+	close(stop)
+	wg.Wait()
+
+	// Leave the package globals in the clean post-reset state.
+	ResetForTesting()
+}

--- a/internal/teststack/stack.go
+++ b/internal/teststack/stack.go
@@ -582,7 +582,13 @@ func (s *Stack) Close() {
 		s.t.Logf("teststack: goroutines did not exit within 5s of Close (continuing teardown)")
 	}
 
-	// Clean up package-level state so the next test starts fresh.
+	// Clean up package-level state so the next test starts fresh. These
+	// resets are safe to run even while the SkipLeakCheck configurations'
+	// tolerated straggler goroutines are still live: every package global
+	// each reset touches (hub, agent, and client stop channels, verbose
+	// flags, MTU, and the rest) is accessed only through a synchronized
+	// accessor or an atomic, so a concurrent reader cannot race the reset
+	// (card tela-79).
 	hub.ResetForTesting()
 	agent.ResetForTesting()
 	client.ResetForTesting()


### PR DESCRIPTION
CI's -race run intermittently failed on main merges because the teststack teardown resets package-level globals in internal/agent and internal/client while goroutines the harness deliberately tolerates (SkipLeakCheck) are still reading them. Teardown reordering cannot fix a supported live-reader state, so this synchronizes the globals themselves: stopCh moves behind RWMutex accessors (stopChan/newStopCh/ensureStopCh/closeStopCh/clearStopCh, with idempotent close), and verbose, reregisterNeeded, and client tunnelMTU become atomics. New TestResetForTestingConcurrentAccess regression tests in both packages make the race a deterministic -race trigger instead of a scheduling lottery.

The green Linux CI run on this PR (full suite under -race, including the new tests) is the acceptance proof.

Card: tela-79

🤖 Generated with [Claude Code](https://claude.com/claude-code)